### PR TITLE
listpath --> list

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v1.1.0
+------
+
+* Rename ``stor.listpath`` to ``stor.list`` for simplicity.
+
 v1.0.0
 ------
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -61,7 +61,7 @@ expand = _delegate_to_path('expand')
 join = _delegate_to_path('joinpath')
 split = _delegate_to_path('splitpath')
 splitext = _delegate_to_path('splitext')
-listpath = _delegate_to_path('list')
+list = _delegate_to_path('list')
 listdir = _delegate_to_path('listdir')
 glob = _delegate_to_path('glob')
 exists = _delegate_to_path('exists')
@@ -74,6 +74,16 @@ getsize = _delegate_to_path('getsize')
 remove = _delegate_to_path('remove')
 rmtree = _delegate_to_path('rmtree')
 walkfiles = _delegate_to_path('walkfiles')
+
+
+def listpath(pth):
+    import warnings
+
+    # DeprecationWarnings are hidden by default. We want to get rid of this
+    # sooner rather than later.
+    warnings.warn('Using the ``stor.listpath()`` function directly is'
+                  ' deprecated, use ``stor.list()`` instead', UserWarning)
+    return list(pth)
 
 
 def path(pth):  # pragma: no cover

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -289,7 +289,7 @@ def create_parser():
                              help='Limit the amount of results returned.',
                              type=int,
                              metavar='INT')
-    parser_list.set_defaults(func=stor.listpath)
+    parser_list.set_defaults(func=stor.list)
 
     ls_msg = 'List path as a directory.'
     parser_ls = subparsers.add_parser('ls',  # noqa


### PR DESCRIPTION
Initially didn't want to call it `list` because it would shadow Python
builtin but it's less confusing to use same name in object API, functional API
and CLI.

Pretty trivial PR, no instances of listpath in tests anyways (I guess since we were testing underlying functional API).

=> @wesleykendall / @phanieste