### PR TITLE
Ignore distribution not found errors

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,6 +5,7 @@ v1.1.1
 ------
 
 * Clarify ``stor.glob()``'s strange calling format (that will be altered in a future version of the library).
+* Ignore ``DistributionNotFound`` error in weird install situations.
 
 v1.1.0
 ------

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -32,7 +32,11 @@ from stor import settings
 
 
 # TODO: Compile this - costs ~700us to do this on import
-__version__ = pkg_resources.get_distribution('stor').version
+try:
+    __version__ = pkg_resources.get_distribution('stor').version
+except pkg_resources.DistributionNotFound:
+    # we are not pip installed in environment
+    __version__ = None
 
 
 settings._initialize()


### PR DESCRIPTION
@wesleykendall cc @phanieste - ignores distribution not found errors when not pip installed, making it easier to futz around when working in develop mode.