### PR TITLE
Clarify top-level glob signature

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v1.1.1
+------
+
+* Clarify ``stor.glob()``'s strange calling format (that will be altered in a future version of the library).
+
 v1.1.0
 ------
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -63,7 +63,6 @@ split = _delegate_to_path('splitpath')
 splitext = _delegate_to_path('splitext')
 list = _delegate_to_path('list')
 listdir = _delegate_to_path('listdir')
-glob = _delegate_to_path('glob')
 exists = _delegate_to_path('exists')
 isabs = _delegate_to_path('isabs')
 isdir = _delegate_to_path('isdir')
@@ -74,6 +73,15 @@ getsize = _delegate_to_path('getsize')
 remove = _delegate_to_path('remove')
 rmtree = _delegate_to_path('rmtree')
 walkfiles = _delegate_to_path('walkfiles')
+
+
+def glob(pth, pattern):
+    """ Glob for pattern relative to ``pth``.
+
+    Note that Swift currently only supports a single trailing *"""
+    # TODO(jtratner): support single argument for glob, which is more
+    # comprehensible.
+    return Path(pth).glob(pattern)
 
 
 def listpath(pth):


### PR DESCRIPTION
@wesleykendall cc @phanieste - we accidentally left in toplevel `glob()` in this library.   Since it doesn't really work at the moment (have to pass two arguments that don't really make sense), I just changed the top-level implementation to take in 2 arguments and correctly explain what they mean.

When we implement a single argument glob, we can just allow `pattern=None`.