### PR TITLE
Add travis and additional tests for 100% coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: python
+python:
+  - '2.7'
+  - '3.4'
+install:
+  - make setup
+script:
+  # Check build
+  - make
+  # Flake8
+  - make lint
+  # Testing with coverage
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - '2.7'
-  - '3.4'
+  - '3.5'
 install:
   - make setup
 script:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v1.1.1
+------
+
+* Added .travis.yml for testing against Python 2 and 3
+* Added additional coverage to get to 100%
+* Updated package classifiers
+
 v1.1.0
 ------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,7 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Framework :: Django
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable    
     Operating System :: OS Independent
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author-email = opensource@counsyl.com
 summary = Cross-compatible API for accessing Posix and OBS storage systems
 description-file = README.md
 home-page = https://github.com/counsyl/stor
-requires-python = >=2.7,<3
+requires-python = >=2.7
 license = Copyright Counsyl, Inc.
 classifier =
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
@@ -13,6 +13,8 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
     Development Status :: 5 - Production/Stable    
     Operating System :: OS Independent
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -34,7 +34,7 @@ from stor import settings
 # TODO: Compile this - costs ~700us to do this on import
 try:
     __version__ = pkg_resources.get_distribution('stor').version
-except pkg_resources.DistributionNotFound:
+except pkg_resources.DistributionNotFound:  # pragma: nocover
     # we are not pip installed in environment
     __version__ = None
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -34,7 +34,7 @@ from stor import settings
 # TODO: Compile this - costs ~700us to do this on import
 try:
     __version__ = pkg_resources.get_distribution('stor').version
-except pkg_resources.DistributionNotFound:  # pragma: nocover
+except pkg_resources.DistributionNotFound:  # pragma: no cover
     # we are not pip installed in environment
     __version__ = None
 

--- a/stor/tests/test_posix.py
+++ b/stor/tests/test_posix.py
@@ -255,6 +255,13 @@ class TestList(unittest.TestCase):
                                                './dir/dir2/file4.txt']))
 
 
+class TestListpath(unittest.TestCase):
+    @mock.patch('stor.list', autospec=True)
+    def test_deprecated_listpath(self, mock_list):
+        stor.listpath('.')
+        mock_list.assert_called_once_with('.')
+
+
 class TestWalkfiles(unittest.TestCase):
     def test_walkfiles(self):
         with NamedTemporaryDirectory(change_dir=True):

--- a/stor/tests/test_posix.py
+++ b/stor/tests/test_posix.py
@@ -234,7 +234,7 @@ class TestGlob(unittest.TestCase):
             open('file2.txt', 'w').close()
             open('file3', 'w').close()
 
-            files = Path('.').glob('*.txt')
+            files = stor.glob('.', '*.txt')
             self.assertEquals(set(files), set(['./file.txt', './file2.txt']))
 
 

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -46,6 +46,19 @@ def _make_stat_response(stat_response=None):
     return [defaults]
 
 
+class TestPathcedGetAuthKeystone(unittest.TestCase):
+    @mock.patch('stor.swift.real_get_auth_keystone', autospec=True)
+    def test_patched_get_auth_keystone(self, mock_get_real_auth_keystone):
+        mock_get_real_auth_keystone.side_effect = Exception
+        os_options = {'auth_token': 'token'}
+        with self.assertRaises(Exception):
+            swift.patched_get_auth_keystone('auth_url', 'user', 'key', os_options)
+        mock_get_real_auth_keystone.assert_called_once_with(
+            'auth_url', 'user', 'key', os_options)
+        # Verify the os_options were modified to pop the auth token
+        self.assertEquals(os_options, {})
+
+
 class TestBasicPathMethods(unittest.TestCase):
     def test_name(self):
         p = Path('swift://tenant/container/path/to/resource')


### PR DESCRIPTION
@jtratner this provides the following:

1. Integrates travis and tests against py2.7 and py3.5
2. Updates our package classifiers
3. Adds tests for the deprecated listpath and the patching we had to do for python-swiftclient