### PR TITLE
Skip broken symlinks on walk files and dirs

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v1.1.2
+------
+
+* Skip broken symlinks during upload, download and listing of files, allowing
+  ``copytree``, ``list`` to work on folders that contain broken symlinks.
+
 v1.1.1
 ------
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -34,7 +34,7 @@ from stor import settings
 # TODO: Compile this - costs ~700us to do this on import
 try:
     __version__ = pkg_resources.get_distribution('stor').version
-except pkg_resources.DistributionNotFound:
+except pkg_resources.DistributionNotFound:  # pragma: no cover
     # we are not pip installed in environment
     __version__ = None
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -79,7 +79,7 @@ rmtree = _delegate_to_path('rmtree')
 walkfiles = _delegate_to_path('walkfiles')
 
 
-def glob(pth, pattern):
+def glob(pth, pattern):  # pragma: no cover
     """ Glob for pattern relative to ``pth``.
 
     Note that Swift currently only supports a single trailing *"""
@@ -88,7 +88,7 @@ def glob(pth, pattern):
     return Path(pth).glob(pattern)
 
 
-def listpath(pth):
+def listpath(pth):  # pragma: no cover
     import warnings
 
     # DeprecationWarnings are hidden by default. We want to get rid of this

--- a/stor/base.py
+++ b/stor/base.py
@@ -260,7 +260,9 @@ class Path(text_type):
         raise NotImplementedError
 
     def list(self, *args, **kwargs):
-        """List all contents using the path as a prefix."""
+        """List all contents using the path as a prefix.
+
+        Note: Skips broken symlinks."""
         raise NotImplementedError
 
     def listdir(self):

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -120,7 +120,7 @@ class TestWalkFilesAndDirs(unittest.TestCase):
             # put something in symlink source so that Python doesn't complain
             with stor.open(symlink_source, 'wb') as fp:
                 fp.write('blah')
-            os.link(symlink_source, symlink)
+            os.symlink(symlink_source, symlink)
             uploads = utils.walk_files_and_dirs([swift_dir])
             print uploads
             self.assertEquals(set(uploads), set([
@@ -130,7 +130,7 @@ class TestWalkFilesAndDirs(unittest.TestCase):
                 symlink_source,
             ]))
             # NOW: destroy it with fire and we have empty directory
-            symlink_source.remove()
+            os.remove(symlink_source)
             uploads = utils.walk_files_and_dirs([swift_dir])
             print uploads
             self.assertEquals(set(uploads), set([
@@ -148,6 +148,20 @@ class TestWalkFilesAndDirs(unittest.TestCase):
                 subdir,
                 swift_dir / 'data_dir' / 'file2',
             ]))
+            # finally make enough symlinks to trigger log trimming (currently
+            # untested but we want to make sure we don't error) + hits some
+            # issues if path to the test file is so long that even 1 file is >
+            # 50 characters, so we skip coverage check because it's not
+            # worth the hassle to get full branch coverage for big edge case
+            super_long_name = tmp_dir / 'abcdefghijklmnopqrstuvwxyzrsjexcasdfawefawefawefawefaef'
+            for x in range(5):
+                os.symlink(super_long_name, super_long_name + str(x))
+            # have no errors! yay!
+            uploads = utils.walk_files_and_dirs([swift_dir])
+            for x in range(5, 20):
+                os.symlink(super_long_name, super_long_name + str(x))
+            # have no errors! yay!
+            uploads = utils.walk_files_and_dirs([swift_dir])
 
 
 

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -75,36 +75,31 @@ class TestIsS3Path(unittest.TestCase):
 
 
 class TestWalkFilesAndDirs(unittest.TestCase):
+    swift_dir = (
+        Path(__file__).expand().abspath().parent /
+        'swift_upload'
+    )
+
     def test_w_dir(self):
         # Create an empty directory for this test in ./swift_upload. This
         # is because git doesnt allow a truly empty directory to be checked
         # in
-        swift_dir = (
-            Path(__file__).expand().abspath().parent /
-            'swift_upload'
-        )
-        with utils.NamedTemporaryDirectory(dir=swift_dir) as tmp_dir:
-            uploads = utils.walk_files_and_dirs([swift_dir])
+        with utils.NamedTemporaryDirectory(dir=self.swift_dir) as tmp_dir:
+            uploads = utils.walk_files_and_dirs([self.swift_dir])
             self.assertEquals(set(uploads), set([
-                swift_dir / 'file1',
+                self.swift_dir / 'file1',
                 tmp_dir,
-                swift_dir / 'data_dir' / 'file2',
+                self.swift_dir / 'data_dir' / 'file2',
             ]))
 
     def test_w_file(self):
-        name = (
-            Path(__file__).expand().abspath().parent /
-            'swift_upload' / 'file1'
-        )
+        name = self.swift_dir / 'file1'
 
         uploads = utils.walk_files_and_dirs([name])
         self.assertEquals(set(uploads), set([name]))
 
-    def test_w_invalid_file(self):
-        name = (
-            Path(__file__).expand().abspath().parent /
-            'swift_upload' / 'invalid'
-        )
+    def test_w_missing_file(self):
+        name = self.swift_dir / 'invalid'
 
         with self.assertRaises(ValueError):
             utils.walk_files_and_dirs([name])
@@ -148,6 +143,9 @@ class TestWalkFilesAndDirs(unittest.TestCase):
                 subdir,
                 swift_dir / 'data_dir' / 'file2',
             ]))
+
+    def test_broken_symlink_file_name_truncation(self):
+        with stor.NamedTemporaryDirectory(dir=self.swift_dir) as tmp_dir:
             # finally make enough symlinks to trigger log trimming (currently
             # untested but we want to make sure we don't error) + hits some
             # issues if path to the test file is so long that even 1 file is >
@@ -157,12 +155,11 @@ class TestWalkFilesAndDirs(unittest.TestCase):
             for x in range(5):
                 os.symlink(super_long_name, super_long_name + str(x))
             # have no errors! yay!
-            uploads = utils.walk_files_and_dirs([swift_dir])
+            self.assert_(utils.walk_files_and_dirs([self.swift_dir]))
             for x in range(5, 20):
                 os.symlink(super_long_name, super_long_name + str(x))
             # have no errors! yay!
-            uploads = utils.walk_files_and_dirs([swift_dir])
-
+            self.assert_(utils.walk_files_and_dirs([self.swift_dir]))
 
 
 class TestNamedTemporaryDirectory(unittest.TestCase):

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -408,21 +408,50 @@ def walk_files_and_dirs(files_and_dirs):
         >>> print results
         ['file_name', 'dir_name/file1', 'dir_name/file2']
     """
+    def _safe_get_size(name):
+        """Get the size of a file, handling weird edge cases like broken
+        symlinks by returning None"""
+        try:
+            return os.path.getsize(name)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return None
+            else:
+                raise
+
     walked_upload_names_and_sizes = {}
+    non_existent_files = []
     for name in files_and_dirs:
         if os.path.isfile(name):
-            walked_upload_names_and_sizes[name] = os.path.getsize(name)
+            walked_upload_names_and_sizes[name] = _safe_get_size(name)
         elif os.path.isdir(name):
             for (root_dir, dir_names, file_names) in os.walk(name):
                 if not (dir_names + file_names):
                     # Ensure that empty directories are uploaded as well
                     walked_upload_names_and_sizes[root_dir] = 0
                 else:
+                    sizes = []
                     for file_name in file_names:
                         full_name = os.path.join(root_dir, file_name)
-                        walked_upload_names_and_sizes[full_name] = os.path.getsize(full_name)
+                        sz = _safe_get_size(full_name)
+                        if sz is not None:
+                            sizes.append(sz)
+                            walked_upload_names_and_sizes[full_name] = sz
+                        else:
+                            non_existent_files.append(full_name)
+                    if not sizes and not dir_names:
+                        # now we have an empty directory
+                        walked_upload_names_and_sizes[root_dir] = 0
         else:
             raise ValueError('file "%s" not found' % name)
+
+    if non_existent_files:
+        file_list = ','.join(non_existent_files[:10])
+        if len(file_list) > 50 or len(non_existent_files) > 10:  # pragma: no cover
+            file_list = file_list[:50] + '...'
+        logger.warn('Skipping %d non existent files in {!r}. Files: %s'.format(
+                    ','.join(files_and_dirs)), len(non_existent_files),
+                    file_list)
 
     return walked_upload_names_and_sizes
 

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -416,7 +416,7 @@ def walk_files_and_dirs(files_and_dirs):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 return None
-            else:
+            else:  # pragma: no cover
                 raise
 
     walked_upload_names_and_sizes = {}


### PR DESCRIPTION
Previously, a broken symlink would be generated by walkfiles, but calling getsize() on it would cause an OSError, borking uploads.  (swift CLI also prints error to console on this, but will still do bulk upload).

This PR handles broken symlink edge case correctly by skipping it in output from walk_files_and_dirs, and returning directories that are empty except for broken symlinks (still rare).

@wesleykendall to review (fixes issue we've been having in production where we were deleting a file during clean up that had a symlink pointing to it, causing upload to fail).