### PR TITLE
Always include transaction ID if available on swift error messages

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v1.2.0
+------
+
+* Include ``X-Trans-Id`` header in Swift exception messages and reprs if
+  available to facilitate debugging.
+
 v1.1.2
 ------
 


### PR DESCRIPTION
e.g.:

```
>>> stor.listdir('swift://AUTH_blah/blah')
UnauthorizedError: Container GET failed: .../v1/AUTH_blah/blah?format=json&delimiter=/ 403 Forbidden  [first 60 chars of response] <html><h1>Forbidden</h1><p>Access was denied to this resourc X-Trans-Id: txaf2eb6f8ffa94215bafc0-005805ad59
```

Makes it much easier to grep through logs for patterns and doesn't add too much to logs (but much easier than forcing users to manually get at this attribute).

=> @wesleykendall 