### PR TITLE
Add detection for SwiftStack-s3 style segment containers

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+v1.3.0
+------
+* When deleting a swift container, also attempt to delete
+  ``$CONTAINER+segments``, which is the format that SwiftStack's S3 emulation
+  layer uses for multipart uploads.  (really tiny perf impact, since it only
+  applies when directly working with containers).
+
+v1.2.2
+------
+* Include ``X-Trans-Id`` on auth failures as well.
+
 v1.2.1
 ------
 * Add explicit dependence on six to requirements.txt

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -442,7 +442,9 @@ class SwiftPath(OBSPath):
         """True if this path is a segment container"""
         container = self.container
         if not self.resource and container:
-            return container.startswith('.segments_') or container.endswith('_segments')
+            return (container.startswith('.segments_') or
+                    container.endswith('_segments') or
+                    container.endswith('+segments'))
         else:
             return False
 
@@ -1286,7 +1288,8 @@ class SwiftPath(OBSPath):
             # do this automatically
             if not deleting_segments:
                 segment_containers = ('%s_segments' % to_delete.container,
-                                      '.segments_%s' % to_delete.container)
+                                      '.segments_%s' % to_delete.container,
+                                      '%s+segments' % to_delete.container)
                 for segment_container in segment_containers:
                     _ignore_not_found(self._swift_service_call)('delete',
                                                                 segment_container,

--- a/stor/tests/test_integration_swift.py
+++ b/stor/tests/test_integration_swift.py
@@ -360,3 +360,18 @@ class SwiftIntegrationTest(BaseIntegrationTest.BaseTestCases):
                         'test',
                         use_manifest=True,
                         num_retries=0)
+
+    def test_all_segment_container_types_are_deleted(self):
+        segment_containers = [stor.join('swift://' + self.test_container.tenant,
+                                        fmt % self.test_container.name)
+                              for fmt in ('.segments_%s', '%s+segments', '%s_segments')]
+        all_containers = segment_containers + [self.test_container]
+
+        test_files = [stor.join(c, 'test_file_tbdeleted.txt') for c in all_containers]
+        for t in test_files:
+            with stor.open(t, 'w') as fp:
+                fp.write('testtxt\n')
+        assert all(t.exists() for t in test_files)
+        stor.rmtree(self.test_container)
+        for t in test_files:
+            assert not t.exists(), 'Did not delete %s' % t

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -2293,7 +2293,8 @@ class TestRmtree(SwiftTestCase):
         self.assertEquals(self.mock_swift.delete.call_args_list,
                           [mock.call('container'),
                            mock.call('container_segments'),
-                           mock.call('.segments_container')])
+                           mock.call('.segments_container'),
+                           mock.call('container+segments')])
 
     @mock.patch('time.sleep', autospec=True)
     def test_w_list_validation_failing_first_time(self, mock_sleep):
@@ -2314,9 +2315,11 @@ class TestRmtree(SwiftTestCase):
                           [mock.call('container'),
                            mock.call('container_segments'),
                            mock.call('.segments_container'),
+                           mock.call('container+segments'),
                            mock.call('container'),
                            mock.call('container_segments'),
-                           mock.call('.segments_container')])
+                           mock.call('.segments_container'),
+                           mock.call('container+segments')])
         self.assertTrue(len(mock_list.call_args_list), 2)
         self.assertTrue(len(mock_sleep.call_args_list), 1)
 
@@ -2340,6 +2343,7 @@ class TestRmtree(SwiftTestCase):
     def test_w_only_container_no_segment_container(self):
         self.mock_swift.delete.side_effect = [{},
                                               swift.NotFoundError('not found'),
+                                              swift.NotFoundError('not found'),
                                               swift.NotFoundError('not found')]
         swift_p = SwiftPath('swift://tenant/container')
         swift_p.rmtree()
@@ -2347,7 +2351,8 @@ class TestRmtree(SwiftTestCase):
         self.assertEquals(self.mock_swift.delete.call_args_list,
                           [mock.call('container'),
                            mock.call('container_segments'),
-                           mock.call('.segments_container')])
+                           mock.call('.segments_container'),
+                           mock.call('container+segments')])
 
     def test_w_container_and_resource(self):
         self.mock_swift.delete.return_value = {}


### PR DESCRIPTION
## Purpose

SwiftStack's S3 emulation layer creates segment containers that look like `$CONTAINER+segments` on multipart uploads.  This is a third format for segment containers, in addition to swiftclient's `$CONTAINER_segments` and stor's `.segments_CONTAINER`.

I don't see any explicit docs from SwiftStack about it, just happened when I noticed weird `ABCD+segments` containers internally.

## How this was tested

1. Added failing integration test and confirmed it failed
2. Updated code to check for segment container and confirmed integration + unit tests pass
3. Confirmed that `stor list swift://AUTH_sometenant` no longer shows `+segments` containers.

@wesleykendall @kyleabeauchamp @krhaas 