### PR TITLE
Ensure that OBS file cleans itself up when GC'd

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v1.3.1
+------
+
+* Ensure OBSFile cleans itself up (commits to remote / deletes local buffer /
+  etc) even when not used in ``with`` statement.
+
 v1.3.0
 ------
 * When deleting a swift container, also attempt to delete

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# have to explicitly ban certain requests versions to match keystoneauth1 package
+requests!=2.12.2,!=2.13.0,>=2.10.0
 boto3>=1.4.0
 cached_property
 python-keystoneclient>=1.8.1

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -272,6 +272,9 @@ class OBSFile(object):
         # give users access to underlying buffer)
         return self
 
+    def __del__(self):
+        self.close()
+
     @cached_property
     def _buffer(self):
         "Cached buffer of data read from or to be written to Object Storage"
@@ -302,6 +305,8 @@ class OBSFile(object):
         return self._path
 
     def close(self):
+        if self.closed:
+            return
         if self.mode in self._WRITE_MODES:
             self.flush()
         self._buffer.close()

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -145,8 +145,17 @@ class BaseIntegrationTest:
                         assert_same_data(remote_gzip_fp, local_gzip_fp)
 
         def test_file_read_write(self):
+            non_with_file = self.test_dir / 'nonwithfile.txt'
             test_file = self.test_dir / 'test_file.txt'
             copy_file = self.test_dir / 'copy_file.txt'
+
+            fp = stor.open(non_with_file, mode='wb')
+            fp.write('blah')
+            del fp
+
+            self.assertTrue(non_with_file.exists())
+            self.assertTrue(non_with_file.isfile())
+            self.assertFalse(non_with_file.isdir())
 
             with test_file.open(mode='wb') as obj:
                 obj.write('this is a test\n')


### PR DESCRIPTION
Otherwise you end up not committing files if used (granted, unPythonically) in format `something.to_csv(stor.open(mypath, 'w'))`.

Better to be non-surprising than unclean ;)

I'm totally fine with merging py3 PR before this one if it matters.

@wesleykendall / @krhaas / @kyleabeauchamp to review

cc @pkaleta