### PR TITLE
Force tox to actually run 3.5 tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ freezegun==0.3.6
 mock==1.3.0
 nose==1.3.7
 testfixtures==4.7.0
+coverage==4.0.3

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,6 +1,5 @@
 # Requirements needed for the setup make target and the test target
 # outside of the individual tox environments.
 
-coverage==4.0.3
 tox==2.1.1
 xunitmerge==1.0.4

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 install_command = pip install {opts} {packages}
 indexserver =
     default = https://pypi.python.org/simple/
-envlist = py27,py34,py35
+envlist = py27,py35
 
 [testenv]
 usedevelop = True
@@ -15,7 +15,6 @@ deps =
   -r{toxinidir}/requirements-dev.txt
 whitelist_externals = make
                       bash
-                      coverage
                       nosetests
 passenv = SWIFT_TEST_USERNAME SWIFT_TEST_PASSWORD OS_TEMP_URL_KEY
           AWS_TEST_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID


### PR DESCRIPTION
This only matters for internal Counsyl CI.

And remove python 3.4 which I don't think we have installed internally.
(since Travis runs it, not a big deal)

Fixes #26 

@kyleabeauchamp @wesleykendall @pkaleta  to review