### PR TITLE
Fix no subparser error on python3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v1.4.2
+------
+
+* Fix error message output when specifying ``stor`` without a command under Python 3.
+
 v1.4.1
 ------
 

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -274,7 +274,8 @@ def create_parser():
                         action='version',
                         version=stor.__version__)
 
-    subparsers = parser.add_subparsers(dest='cmd', metavar='')
+    subparsers = parser.add_subparsers(dest='cmd')
+    subparsers.required = True
 
     list_msg = 'List contents using the path as a prefix.'
     parser_list = subparsers.add_parser('list',

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -102,6 +102,14 @@ class TestCliBasics(BaseCliTest):
             self.parse_args('stor list some_path')
         self.assertIn('not a valid command', sys.stderr.getvalue())
 
+    @mock.patch('sys.stderr', new=six.StringIO())
+    def test_no_cmd_provided(self):
+        with mock.patch.object(sys, 'argv', ['stor']):
+            with self.assertRaisesRegexp(SystemExit, '2'):
+                cli.main()
+        self.assertIn('stor: error:', sys.stderr.getvalue())
+        self.assertIn('arguments', sys.stderr.getvalue())
+
 
 @mock.patch('stor.cli._get_pwd', autospec=True)
 class TestGetPath(BaseCliTest):


### PR DESCRIPTION
Fix error message output when specifying `stor` without a command under Python 3.

props to this SO error for explaining - http://stackoverflow.com/questions/22990977/why-does-this-argparse-code-behave-differently-between-python-2-and-3