### PR TITLE
Add stor.utils.is_writeable.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
-    Development Status :: 5 - Production/Stable    
+    Development Status :: 5 - Production/Stable
     Operating System :: OS Independent
 
 [coverage:run]

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -1332,6 +1332,18 @@ class SwiftPath(OBSPath):
 
         return results
 
+    @_swift_retry(exceptions=(UnavailableError, UnauthorizedError))
+    def remove_container(self):
+        """
+        Remove swift container if it's not empty.
+        """
+        if not self.container:
+            raise ValueError('swift path must include container for remove_container')
+        if self.resource:
+            raise ValueError('swift path must not include resource for remove_container')
+
+        return self._swift_connection_call('delete_container', self.container)
+
     @_swift_retry(exceptions=UnavailableError)
     def stat(self):
         """Performs a stat on the path.

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -367,7 +367,13 @@ class TestIsWriteableSwift(unittest.TestCase):
         self.assertTrue(utils.is_writeable('swift://AUTH_stor_test/container/test'))
 
     def test_path_unchanged(self, mock_rmtree, _cp, mock_exists):
-        mock_exists.return_value = False
+        # Make the first call to exists() return False and the second return True.
+        return_values = [False, True]
+
+        def side_effect(*args):
+            return return_values.pop(0)
+        mock_exists.side_effect = side_effect
+
         utils.is_writeable('swift://AUTH_stor_test/container/test')
         mock_rmtree.assert_called_once_with(SwiftPath('swift://AUTH_stor_test/container'))
 

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -331,7 +331,7 @@ class TestIsWriteablePOSIX(unittest.TestCase):
     def test_non_existing_path(self):
         with utils.NamedTemporaryDirectory() as tmp_d:
             non_existing_path = tmp_d / 'does' / 'not' / 'exist'
-            self.assertTrue(utils.is_writeable(non_existing_path))
+            self.assertFalse(utils.is_writeable(non_existing_path))
 
     def test_path_unchanged(self):
         with utils.NamedTemporaryDirectory() as tmp_d:
@@ -339,6 +339,7 @@ class TestIsWriteablePOSIX(unittest.TestCase):
             self.assertFalse(non_existing_path.exists())
             utils.is_writeable(non_existing_path)
             self.assertFalse(non_existing_path.exists())
+            self.assertFalse((tmp_d / 'does').exists())
 
     def test_existing_path_not_removed(self):
         with utils.NamedTemporaryDirectory() as tmp_d:

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -424,7 +424,9 @@ class TestIsWriteableSwift(unittest.TestCase):
         )
 
     def test_container_created_in_another_client(self):
-        self.mock_exists.return_value = False
+        # Simulate that container doesn't exist at the beginning, but is created after the
+        # is_writeable is called.
+        self.mock_exists.side_effect = [False, True]
         self.mock_remove_container.side_effect = stor.swift.ConflictError('foo')
         self.assertTrue(utils.is_writeable('swift://AUTH_stor_test/container/'))
 

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -373,12 +373,7 @@ class TestIsWriteableSwift(unittest.TestCase):
 
     def test_path_unchanged(self, _tmp, _remove, mock_rmtree, _cp, mock_exists):
         # Make the first call to exists() return False and the second return True.
-        return_values = [False, True]
-
-        def side_effect(*args):
-            return return_values.pop(0)
-        mock_exists.side_effect = side_effect
-
+        mock_exists.side_effect = [False, True]
         utils.is_writeable('swift://AUTH_stor_test/container/test')
         mock_rmtree.assert_called_once_with(SwiftPath('swift://AUTH_stor_test/container'))
 

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -387,6 +387,14 @@ class TestIsWriteableSwift(unittest.TestCase):
         mock_copy.side_effect = stor.swift.UnauthorizedError('foo')
         self.assertFalse(utils.is_writeable('swift://AUTH_stor_test/container/test'))
 
+    def test_disable_backoff(self, tmpfile, _remove, _rm, mock_copy, _ex):
+        filename = 'test_file'
+        path = Path('swift://AUTH_stor_test/container/test')
+        swift_opts = {'num_retries': 0}
+        tmpfile.return_value.__enter__.return_value.name = filename
+        utils.is_writeable(path, swift_opts)
+        mock_copy.assert_called_with(filename, path, swift_retry_options=swift_opts)
+
 
 @mock.patch('stor.utils.copy')
 @mock.patch('stor.rmtree')

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -385,3 +385,25 @@ class TestIsWriteableSwift(unittest.TestCase):
     def test_path_no_perms(self, _rm, mock_copy, _ex):
         mock_copy.side_effect = stor.swift.UnauthorizedError('foo')
         self.assertFalse(utils.is_writeable('swift://AUTH_stor_test/container/test'))
+
+
+@mock.patch('stor.utils.copy')
+@mock.patch('stor.rmtree')
+@mock.patch('stor.remove')
+@mock.patch('stor.utils.tempfile.NamedTemporaryFile')
+class TestIsWriteableS3(unittest.TestCase):
+    def test_success(self, tmpfile, mock_remove, _rmtree, mock_copy):
+        filename = 'test-file'
+        tmpfile.return_value.__enter__.return_value.name = filename
+        path = 's3://stor-test/foo/bar'
+        self.assertTrue(utils.is_writeable(path))
+        mock_remove.assert_called_with(S3Path('{}/{}'.format(path, filename)))
+
+    def test_existing_path_not_removed(self, _tmp, _remove, mock_rmtree, mock_copy):
+        utils.is_writeable('s3://stor-test/foo/bar')
+        mock_rmtree.assert_not_called()
+
+    def test_path_no_perms(self, _tmp, mock_remove, mock_rmtree, mock_copy):
+        mock_copy.side_effect = stor.exceptions.FailedUploadError('foo')
+        self.assertFalse(utils.is_writeable('s3://stor-test/foo/bar'))
+        mock_remove.assert_not_called()

--- a/stor/tests/test_utils.py
+++ b/stor/tests/test_utils.py
@@ -423,8 +423,10 @@ class TestIsWriteableSwift(unittest.TestCase):
             swift_retry_options=None
         )
 
-    # def test_container_created(self, tmpfile, _remove, _rm, mock_copy, _ex):
-        
+    def test_container_created_in_another_client(self):
+        self.mock_exists.return_value = False
+        self.mock_remove_container.side_effect = stor.swift.ConflictError('foo')
+        self.assertTrue(utils.is_writeable('swift://AUTH_stor_test/container/'))
 
 
 @mock.patch('stor.utils.copy')

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -268,6 +268,7 @@ def is_writeable(path, swift_retry_options=None):
     from stor import rmtree
     from stor.swift import SwiftPath
     from stor.swift import UnauthorizedError
+    from stor.swift import UnavailableError
 
     path = with_trailing_slash(Path(path))
 
@@ -294,7 +295,7 @@ def is_writeable(path, swift_retry_options=None):
             # Attempt to create a file in the `path`.
             copy(tmpfile.name, path, swift_retry_options=swift_retry_options)
             answer = True
-        except (UnauthorizedError, IOError, OSError, exceptions.FailedUploadError):
+        except (UnauthorizedError, UnavailableError, IOError, OSError, exceptions.FailedUploadError):  # nopep8
             answer = False
         else:
             # Remove the file that was created.

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -265,7 +265,7 @@ def is_writeable(path, swift_retry_options=None):
     from stor import join
     from stor import Path
     from stor import remove
-    from stor import rmtree
+    from stor.swift import ConflictError
     from stor.swift import SwiftPath
     from stor.swift import UnauthorizedError
     from stor.swift import UnavailableError
@@ -303,8 +303,11 @@ def is_writeable(path, swift_retry_options=None):
     # Remove the Swift container if it didn't exist when calling this function, but exists
     # now. This way this function remains a no-op with regards to container structure.
     if container_existed is False and container_path.exists():
-        assert not container_path.listdir()
-        rmtree(container_path)
+        try:
+            container_path.remove_container()
+        except ConflictError:
+            # Ignore if some other thread/user created the container in the meantime.
+            pass
 
     return answer
 

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -242,6 +242,7 @@ def is_writeable(path):
     from stor import basename
     from stor import join
     from stor import Path
+    from stor import rmtree
     from stor.swift import SwiftPath
     from stor.swift import UnauthorizedError
 
@@ -251,6 +252,7 @@ def is_writeable(path):
     if is_filesystem_path(path):
         base_path = path
         base_path_existed = path.exists()
+        make_dest_dir(path)
     elif is_swift_path(path):
         base_path = Path('{}{}/{}'.format(
             SwiftPath.drive,
@@ -260,15 +262,13 @@ def is_writeable(path):
         base_path_existed = base_path.exists()
 
     try:
-        make_dest_dir(path)
-
         with tempfile.NamedTemporaryFile() as tmpfile:
             copy(tmpfile.name, path)
             join(path, basename(tmpfile.name)).remove()
 
         if base_path_existed is False:
             assert not base_path.listdir()
-            base_path.rmtree()
+            rmtree(base_path)
 
         return True
     except (UnauthorizedError, IOError):

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -253,7 +253,7 @@ def is_writeable(path):
     # were not present when it was called. The `base_path_existed` defined below will
     # store whether the directory that we're checking existed when calling this function,
     # so that we know if it should be removed at the end.
-    if is_filesystem_path(path):
+    if is_filesystem_path(path) or is_s3_path(path):
         base_path = path
         base_path_existed = path.exists()
         make_dest_dir(path)
@@ -264,8 +264,8 @@ def is_writeable(path):
             path.container
         ))
         base_path_existed = base_path.exists()
-    else:
-        base_path_existed = None
+    else:  # pragma: no cover
+        raise ValueError('Path type not supported: {}'.format(path))
 
     try:
         # Attempt to create a file in the `path`.

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -269,7 +269,7 @@ def is_writeable(path, swift_retry_options=None):
     from stor.swift import SwiftPath
     from stor.swift import UnauthorizedError
 
-    path = Path(path)
+    path = with_trailing_slash(Path(path))
 
     if is_filesystem_path(path):
         return os.access(path, os.W_OK)
@@ -282,7 +282,7 @@ def is_writeable(path, swift_retry_options=None):
         # function that were not present when it was called. The `container_existed`
         # defined below will store whether the container that we're checking existed when
         # calling this function, so that we know if it should be removed at the end.
-        container_path = Path('{}{}/{}'.format(
+        container_path = Path('{}{}/{}/'.format(
             SwiftPath.drive,
             path.tenant,
             path.container

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -294,12 +294,11 @@ def is_writeable(path, swift_retry_options=None):
         try:
             # Attempt to create a file in the `path`.
             copy(tmpfile.name, path, swift_retry_options=swift_retry_options)
+            # Remove the file that was created.
+            remove(join(path, basename(tmpfile.name)))
             answer = True
         except (UnauthorizedError, UnavailableError, IOError, OSError, exceptions.FailedUploadError):  # nopep8
             answer = False
-        else:
-            # Remove the file that was created.
-            remove(join(path, basename(tmpfile.name)))
 
     # Remove the Swift container if it didn't exist when calling this function, but exists
     # now. This way this function remains a no-op with regards to container structure.

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -266,17 +266,19 @@ def is_writeable(path):
     else:  # pragma: no cover
         raise ValueError('Path type not supported: {}'.format(path))
 
-    try:
-        if is_filesystem_path(path):
-            make_dest_dir(path)
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        try:
+            if is_filesystem_path(path):
+                make_dest_dir(path)
 
-        # Attempt to create a file in the `path`.
-        with tempfile.NamedTemporaryFile() as tmpfile:
+            # Attempt to create a file in the `path`.
             copy(tmpfile.name, path)
+            answer = True
+        except (UnauthorizedError, IOError, OSError):
+            answer = False
+        else:
+            # Remove the file that was created.
             join(path, basename(tmpfile.name)).remove()
-        answer = True
-    except (UnauthorizedError, IOError, OSError):
-        answer = False
 
     # Remove the base directory if it didn't exist when calling this function. This
     # way the underlying directories should remain untouched.

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -234,6 +234,16 @@ def is_writeable(path):
     """
     Determine whether we have permission to write to path.
 
+    Behavior of this method is slightly different for different storage types when the
+    directory doesn't exist:
+    1. For local file systems, this function will return True if the target directory can
+       be created and a file written to it.
+    2. For AWS S3, this function will return True only if the target bucket is already
+       present and we have write access to the bucket.
+    3. For Swift, this function will return True, only if the target tenant is already
+       present and we have write access to the tenant and container. The container doesn't
+       have to be present.
+
     This is function is useful, because `stor.stat()` will succeed if we have read-only
     permissions to `path`, but the eventual attempt to upload will fail.
 


### PR DESCRIPTION
@jtratner 

The goal of `stor.utils.is_writeable` is to be able to determine whether we have write access to the specified path, either local, S3 or Swift. This is useful, because using this we'd be able to check for write permissions ahead-of-time, before generating objects for upload, which might take significant amount of time.

Check the docstring and tests for more details.