### PR TITLE
Fix SwiftPath.dirname() for top-level swift paths.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v1.4.3
+------
+
+* Fix ``dirname()`` for top-level Swift paths, like ``swift://``.
+* Fix ``dirname()`` for top-level S3 paths, like ``s3://``.
+
+
 v1.4.2
 ------
 

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -1,3 +1,4 @@
+import os
 import posixpath
 import sys
 
@@ -73,6 +74,14 @@ class OBSPath(Path):
 
     copy = utils.copy
     copytree = utils.copytree
+
+    def dirname(self):
+        """
+        Return the directory name of self.
+        """
+        assert self.startswith(self.drive)
+        rest = self[len(self.drive):]
+        return type(self)(self.drive + os.path.dirname(rest))
 
     def __repr__(self):
         return '%s("%s")' % (type(self).__name__, self)

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -81,7 +81,7 @@ class OBSPath(Path):
         """
         assert self.startswith(self.drive)
         rest = self[len(self.drive):]
-        return self.path_class(self.drive + os.path.dirname(rest))
+        return self.path_class(self.drive + self.path_module.dirname(rest))
 
     def __repr__(self):
         return '%s("%s")' % (type(self).__name__, self)

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -81,7 +81,7 @@ class OBSPath(Path):
         """
         assert self.startswith(self.drive)
         rest = self[len(self.drive):]
-        return type(self)(self.drive + os.path.dirname(rest))
+        return self.path_class(self.drive + os.path.dirname(rest))
 
     def __repr__(self):
         return '%s("%s")' % (type(self).__name__, self)

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -1,4 +1,3 @@
-import os
 import posixpath
 import sys
 

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -438,6 +438,14 @@ class SwiftPath(OBSPath):
     """
     drive = 'swift://'
 
+    def dirname(self):
+        """
+        Return the directory name of self.
+        """
+        assert self.startswith(self.drive)
+        rest = self[len(self.drive):]
+        return SwiftPath(self.drive + os.path.dirname(rest))
+
     def is_segment_container(self):
         """True if this path is a segment container"""
         container = self.container

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -438,14 +438,6 @@ class SwiftPath(OBSPath):
     """
     drive = 'swift://'
 
-    def dirname(self):
-        """
-        Return the directory name of self.
-        """
-        assert self.startswith(self.drive)
-        rest = self[len(self.drive):]
-        return SwiftPath(self.drive + os.path.dirname(rest))
-
     def is_segment_container(self):
         """True if this path is a segment container"""
         container = self.container

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -39,6 +39,13 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('s3://bucket/path/to/resource')
         self.assertEquals(p.dirname(), 's3://bucket/path/to')
 
+    def test_dirname_top_level(self):
+        p1 = Path('s3://')
+        self.assertEquals(p1.dirname(), 's3://')
+
+        p2 = Path('s3://a')
+        self.assertEquals(p2.dirname(), 's3://')
+
     def test_basename(self):
         p = Path('s3://bucket/path/to/resource')
         self.assertEquals(p.basename(), 'resource')

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -72,6 +72,13 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('swift://tenant/container/path/to/resource')
         self.assertEquals(p.dirname(), 'swift://tenant/container/path/to')
 
+    def test_dirname_top_level(self):
+        p1 = Path('swift://')
+        self.assertEquals(p1.dirname(), 'swift://')
+
+        p2 = Path('swift://a')
+        self.assertEquals(p2.dirname(), 'swift://')
+
     def test_basename(self):
         p = Path('swift://tenant/container/path/to/resource')
         self.assertEquals(p.basename(), 'resource')


### PR DESCRIPTION
@jtratner 

There's a bug that occurs when calling `dirname()` on top-level swift paths like `swift://` or `swift://a`:

```
Traceback (most recent call last):
  File "/Users/piotr/counsyl/stor/stor/tests/test_swift.py", line 77, in test_dirname_top_level
    self.assertEquals(p1.dirname(), 'swift://')
  File "/Users/piotr/counsyl/stor/stor/base.py", line 151, in dirname
    return self.path_class(self.path_module.dirname(self))
  File "/Users/piotr/counsyl/stor/stor/obs.py", line 71, in __init__
    raise ValueError('path must have %s (got %r)' % (self.drive, pth))
ValueError: path must have swift:// (got u'swift:')
```

I've fixed it by making stor return `swift://` in those cases. The alternative would be to return an empty string or `None`, but I think the current approach is more consistent with the current behavior of `os` module, where it returns `C:\` and `/` for windows and linux top-level dirs respectively.

I've added a test that demonstrates the bug and made sure that it's fixed with this patch in place.