### PR TITLE
Enable multiple SOURCE(s) for ``stor cp``

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ positional arguments:
 
     list                List contents using the path as a prefix.
     ls                  List path as a directory.
-    cp                  Alias for copy.
+    cp                  Copy a source to a destination path.
+    cpto                Copy a source to a destination path. Note that here
+                        DEST comes before SOURCE(s).
     rm                  Remove file at a path.
     walkfiles           List all files under a path that match an optional
                         pattern.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -8,7 +8,7 @@ To run all tests, type::
 
     make test
 
-In order to run swift integration tests, create a swift tenant called ``AUTH_swft_test`` and provide environment variables for a user that has permissions to write to that tenant (``SWIFT_TEST_USERNAME`` and ``SWIFT_TEST_PASSWORD``). Also set the swift auth url environment variable (``OS_AUTH_URL``)
+In order to run swift integration tests, create a swift tenant called ``AUTH_swft_test`` (override with the ``SWIFT_TEST_TENANT`` environment variable) and provide environment variables for a user that has permissions to write to that tenant (``SWIFT_TEST_USERNAME`` and ``SWIFT_TEST_PASSWORD``). Also set the swift auth url environment variable (``OS_AUTH_URL``). You can set the prefix of the temporary test container via the ``SWIFT_TEST_CONTAINER_PREFIX`` environment variable.
 
 In order to run S3 integration tests, create a ``stor-test-bucket`` S3 bucket and provide environment variables for an AWS user that has permissions to write to it (``AWS_TEST_ACCESS_KEY_ID`` and ``AWS_ACCESS_KEY_ID``).
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -23,7 +23,9 @@ See `stor.swift` for more information on Swift-specific functionality.
 import pkg_resources
 
 from stor.utils import copy
+from stor.utils import copy_multiple
 from stor.utils import copytree
+from stor.utils import copytree_multiple
 from stor.utils import is_filesystem_path
 from stor.utils import is_swift_path
 from stor.utils import NamedTemporaryDirectory
@@ -132,7 +134,9 @@ __all__ = [
     'ismount',
     'getsize',
     'copy',
+    'copy_multiple',
     'copytree',
+    'copytree_multiple',
     'remove',
     'rmtree',
     'walkfiles',

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -55,6 +55,18 @@ class BaseIntegrationTest(object):
                     stor.copy(obj_path, 'copied_file')
                     self.assertCorrectObjectContents('copied_file', which_obj, min_obj_size)
 
+        def test_copy_multiple_to_from_dir(self):
+            num_test_objs = 5
+            min_obj_size = 100
+            with NamedTemporaryDirectory(change_dir=True) as tmp_d:
+                self.create_dataset(tmp_d, num_test_objs, min_obj_size)
+                objs = self.get_dataset_obj_names(num_test_objs)
+                stor.copy_multiple(objs, self.test_dir / "")
+                for which_obj in objs:
+                    obj_path = stor.join(self.test_dir, which_obj)
+                    stor.copy(obj_path, 'copied_file')
+                    self.assertCorrectObjectContents('copied_file', which_obj, min_obj_size)
+
         def test_copytree_to_from_dir(self):
             num_test_objs = 10
             test_obj_size = 100
@@ -73,6 +85,29 @@ class BaseIntegrationTest(object):
                 for which_obj in self.get_dataset_obj_names(num_test_objs):
                     obj_path = Path('test') / which_obj
                     self.assertCorrectObjectContents(obj_path, which_obj, test_obj_size)
+
+        def test_copytree_multiple_to_from_dir(self):
+            num_test_dirs = 10
+            num_test_objs = 2
+            test_obj_size = 100
+            # Create mock dataset and copy all directories
+            with NamedTemporaryDirectory(change_dir=True) as tmp_d:
+                test_dirs = self.get_dataset_obj_names(num_test_dirs)
+                for dirname in test_dirs:
+                    stor.utils.make_dest_dir(dirname)
+                    self.create_dataset(dirname, num_test_objs, test_obj_size)
+                stor.copytree_multiple(test_dirs, self.test_dir / "")
+            # Copy the files back to get contents
+            with NamedTemporaryDirectory(change_dir=True) as tmp_d:
+                for dirname in test_dirs:
+                    (self.test_dir / dirname).copytree(
+                        'test-%s' % dirname,
+                        condition=lambda results: len(results) == num_test_objs)
+
+                    # Verify contents of all downloaded test objects
+                    for which_obj in self.get_dataset_obj_names(num_test_objs):
+                        obj_path = Path('test-%s' % dirname) / which_obj
+                        self.assertCorrectObjectContents(obj_path, which_obj, test_obj_size)
 
         def test_hidden_file_nested_dir_copytree(self):
             with NamedTemporaryDirectory(change_dir=True):

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -379,6 +379,23 @@ def copy(source, dest, swift_retry_options=None):
                                 **swift_retry_options)
 
 
+def copy_multiple(sources, dest, swift_retry_options=None):
+    """Copies many sources to the same destination.
+
+    See ``stor.copy``.
+
+    Args:
+        source (list of path|str): The list of source files.
+        dest (path|str): The destination directory to copy to.
+        swift_retry_options (dict): Optional retry arguments to use for swift
+            upload or download. View the
+            `swift module-level documentation <swiftretry>` for more
+            information on retry arguments
+    """
+    for source in sources:
+        copy(source, dest, swift_retry_options=swift_retry_options)
+
+
 def copytree(source, dest, copy_cmd=None, use_manifest=False, headers=None,
              condition=None, **retry_args):
     """Copies a source directory to a destination directory. Assumes that
@@ -470,6 +487,13 @@ def copytree(source, dest, copy_cmd=None, use_manifest=False, headers=None,
         with source:
             dest.upload(['.'], use_manifest=use_manifest, headers=headers,
                         condition=condition, **retry_args)
+
+
+def copytree_multiple(sources, dest, copy_cmd=None, use_manifest=False,
+                      headers=None, condition=None, **retry_args):
+    for source in sources:
+        copytree(source, dest, copy_cmd=copy_cmd, use_manifest=use_manifest,
+                 headers=headers, condition=condition, **retry_args)
 
 
 def _safe_get_size(name):

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
 whitelist_externals = make
                       bash
                       nosetests
-passenv = SWIFT_TEST_USERNAME SWIFT_TEST_PASSWORD OS_TEMP_URL_KEY
+passenv = SWIFT_TEST_USERNAME SWIFT_TEST_PASSWORD
+          SWIFT_TEST_TENANT SWIFT_TEST_CONTAINER_PREFIX
+          OS_TEMP_URL_KEY
           AWS_TEST_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID
           AWS_SECRET_ACCESS_KEY OS_AUTH_URL


### PR DESCRIPTION
New usage: ``stor cp [-h] [-r] SOURCE [SOURCE ...] DEST``

Also adds ``stor cpto`` which reverses DEST and SOURCE(s) and is useful for e.g. `find . -name '*.csv' | xargs stor cpto swift://tenant/container/prefix/`.

Enable Swift integration to be more flexible by adding more environment variables to control e.g. the tenant.

Note: Somewhat in progress -- `stor.tests.test_integration_swift.SwiftIntegrationTest.test_copytree_multiple_to_from_dir` might not work correctly and `stor cpto` doesn't have tests at the moment.