### PR TITLE
Run posix in integration tests

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,5 +1,10 @@
 Release Notes
 =============
+Latest
+------
+* Auto-create parent directories on the filesystem for `stor.copy`, `stor.open`, and `stor.copytree`.
+* Allow `stor.copytree` to work if it targets an empty target directory (removes the other directory first)
+
 
 v1.4.5
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,8 +2,8 @@ Release Notes
 =============
 Latest
 ------
-* Auto-create parent directories on the filesystem for `stor.copy`, `stor.open`, and `stor.copytree`.
-* Allow `stor.copytree` to work if it targets an empty target directory (removes the other directory first)
+* Auto-create parent directories on the filesystem for ``stor.copy``, ``stor.open``, and ``stor.copytree``.
+* Allow ``stor.copytree`` to work if it targets an empty target directory (removes the other directory first)
 
 
 v1.4.5

--- a/stor/base.py
+++ b/stor/base.py
@@ -359,8 +359,11 @@ class FileSystemPath(Path):
         Opens a path and retains interface compatibility with
         `SwiftPath` by popping the unused ``swift_upload_args`` keyword
         argument.
+
+        Creates parent directory if it does not exist.
         """
         kwargs.pop('swift_upload_kwargs', None)
+        self.parent.makedirs_p()
         return builtins.open(self, *args, **kwargs)
 
     def __enter__(self):
@@ -441,6 +444,9 @@ class FileSystemPath(Path):
     def makedirs_p(self, mode=0o777):
         """ Like :meth:`makedirs`, but does not raise an exception if the
         directory already exists. """
+        if not self:
+            # no point in trying to make an empty relative path :)
+            return
         try:
             self.makedirs(mode)
         except OSError:

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -2,10 +2,13 @@ import gzip
 import os
 import unittest
 
+import six
+
 import stor
 from stor import NamedTemporaryDirectory
 from stor import Path
 from stor.tests.shared import assert_same_data
+
 
 
 class BaseIntegrationTest(object):
@@ -29,6 +32,7 @@ class BaseIntegrationTest(object):
             dependent on the object name and should be taken into consideration
             when testing.
             """
+            Path(directory).makedirs_p()
             with Path(directory):
                 for name in self.get_dataset_obj_names(num_objects):
                     with open(name, 'w') as f:
@@ -43,6 +47,13 @@ class BaseIntegrationTest(object):
                 contents = test_obj.read()
                 expected = self.get_dataset_obj_contents(which_test_obj, min_obj_size)
                 self.assertEquals(contents, expected)
+
+
+        def _skip_if_filesystem_python3(self, dirname, explanation='needs bytes/str fix'):
+            if six.PY2:
+                return
+            if stor.is_filesystem_path(dirname):
+                raise unittest.SkipTest('Skipping filesystem test on Python 3: %s' % explanation)
 
         def test_copy_to_from_dir(self):
             num_test_objs = 5
@@ -113,6 +124,7 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'b/c.sh'),
                 stor.join(self.test_dir, 'b/d'),
                 stor.join(self.test_dir, 'b/abbbc'),
+                stor.join(self.test_dir, 'empty'),
             ]))
             prefix_files = list(self.test_dir.walkfiles('*.sh'))
             self.assertEquals(set(prefix_files), set([
@@ -132,6 +144,7 @@ class BaseIntegrationTest(object):
             ]))
 
         def test_gzip_on_remote(self):
+            self._skip_if_filesystem_python3(self.test_dir)
             local_gzip = os.path.join(os.path.dirname(__file__),
                                       'file_data/s_3_2126.bcl.gz')
             remote_gzip = stor.join(self.test_dir,
@@ -143,6 +156,7 @@ class BaseIntegrationTest(object):
                         assert_same_data(remote_gzip_fp, local_gzip_fp)
 
         def test_file_read_write(self):
+            self._skip_if_filesystem_python3(self.test_dir)
             non_with_file = self.test_dir / 'nonwithfile.txt'
             test_file = self.test_dir / 'test_file.txt'
             copy_file = self.test_dir / 'copy_file.txt'

--- a/stor/tests/test_integration_posix.py
+++ b/stor/tests/test_integration_posix.py
@@ -1,0 +1,27 @@
+from stor.tests.test_integration import BaseIntegrationTest
+import stor
+import six
+
+class FilesystemIntegrationTest(BaseIntegrationTest.BaseTestCases):
+    def setUp(self):
+        super(FilesystemIntegrationTest, self).setUp()
+        ntp_obj = stor.NamedTemporaryDirectory()
+        # ensure that it's empty and does not exist to start
+        self.test_dir = stor.join(ntp_obj.__enter__(), 'parent')
+        self.addCleanup(ntp_obj.__exit__, None, None, None)
+
+    def test_non_empty_directory_errors(self):
+        example_dir = stor.join(self.test_dir, 'example')
+        assert not example_dir.exists()
+        other_dir = stor.join(self.test_dir, 'otherdir')
+        self.create_dataset(other_dir, 1, 1)
+        self.create_dataset(example_dir, 1, 1)
+        example_dir.makedirs_p()
+        exc_type = OSError if six.PY2 else FileExistsError  # nopep8
+        with self.assertRaisesRegexp(exc_type, '.*File exists'):
+            try:
+                stor.copytree(other_dir, example_dir)
+            except exc_type as e:
+                assert e.errno == 17
+                raise
+

--- a/stor/tests/test_integration_swift.py
+++ b/stor/tests/test_integration_swift.py
@@ -37,7 +37,7 @@ class SwiftIntegrationTest(BaseIntegrationTest.BaseTestCases):
                 'num_retries': 5
             }})
 
-        self.test_container = Path('swift://%s/%s' % ('AUTH_swft_test', uuid.uuid4()))
+        self.test_container = Path('swift://%s/%s' % ('AUTH_%s' % os.environ['SWIFT_TEST_USERNAME'], uuid.uuid4()))
         if self.test_container.exists():
             raise ValueError('test container %s already exists.' % self.test_container)
 

--- a/stor/tests/test_integration_swift.py
+++ b/stor/tests/test_integration_swift.py
@@ -36,8 +36,10 @@ class SwiftIntegrationTest(BaseIntegrationTest.BaseTestCases):
                 'password': os.environ.get('SWIFT_TEST_PASSWORD'),
                 'num_retries': 5
             }})
+        # fall back on to swiftstack auth for tenant
+        tenant = os.environ.get('SWIFT_TEST_TENANT', 'AUTH_%s' % os.environ['SWIFT_TEST_USERNAME'])
 
-        self.test_container = Path('swift://%s/%s' % ('AUTH_%s' % os.environ['SWIFT_TEST_USERNAME'], uuid.uuid4()))
+        self.test_container = Path('swift://%s/%s' % (tenant, uuid.uuid4()))
         if self.test_container.exists():
             raise ValueError('test container %s already exists.' % self.test_container)
 

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -361,6 +361,7 @@ def copy(source, dest, swift_retry_options=None):
         raise ValueError('OBS destination must be file with extension or directory with slash')
 
     if is_filesystem_path(dest):
+        dest.parent.makedirs_p()
         if is_obs_path(source):
             dest_file = dest if not dest.isdir() else dest / source.name
             source.download_object(dest_file, **swift_retry_options)


### PR DESCRIPTION
@pkaleta @kyleabeauchamp - sets up the stor integration tests to run against POSIX as well.  This would have surfaced the issues with `stor.open()` in Python3 land way earlier :)

For now, I've added a skip test to the tests that fail in Python 3, so then @kyleabeauchamp can remove them after his PR merges and fixes the underlying problem.

(In my estimation @kyleabeauchamp I think you'd just need to add one test that opens with 'wb' and another that opens just with 'w')

I'd like to get these tests to pass (with whatever skips) as a minimal PR and then use this in your work @kyleabeauchamp .