### PR TITLE
Fix Posix + S3 integration tests

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,7 @@ v1.5.0
 * Auto-create parent directories on the filesystem for ``stor.copy``, ``stor.open``, and ``stor.copytree``.
 * Allow ``stor.copytree`` to work if it targets an empty target directory (removes the other directory first)
 * Fix file read/write behavior in Python 3.
+* Fix S3 integration tests so they are easier to run.
 
 
 v1.4.6

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,6 +8,8 @@ v1.5.0
 * Allow ``stor.copytree`` to work if it targets an empty target directory (removes the other directory first)
 * Fix file read/write behavior in Python 3.
 * Fix S3 integration tests so they are easier to run.
+* Fix inconsistency with ``walkfiles()`` on ``PosixPath`` so that it does not
+  return empty directories (causes a small potential perf hit).
 
 
 v1.4.6

--- a/stor/default.cfg
+++ b/stor/default.cfg
@@ -2,6 +2,18 @@
 
 [s3]
 
+# See boto3 docs for more detail on these parameters - all passed directly to boto3.session.Session *if* set
+# aws_access_key_id (string) -- AWS access key ID
+aws_access_key_id =
+# aws_secret_access_key (string) -- AWS secret access key
+aws_secret_access_key =
+# aws_session_token (string) -- AWS temporary session token
+aws_session_token =
+# region_name (string) -- Default region when creating new connections
+region_name =
+# profile_name (string) -- The name of a profile to use. If not given, then the default profile is used.
+profile_name =
+
 [s3:upload]
 # segment_size (int|str): Upload files in segments no larger than 
 #   <segment_size> (in bytes). Sizes may also be expressed as bytes with 

--- a/stor/posix.py
+++ b/stor/posix.py
@@ -1,6 +1,7 @@
 """
 Provides functionality for accessing resources on Posix file systems.
 """
+import os
 import posixpath
 
 from stor import base
@@ -39,7 +40,9 @@ class PosixPath(base.FileSystemPath):
 
         Returns:
             Iter[Path]: Files recursively under the path
+        Note:
+            This may be much slower than list() because it checks twice that everything is a file.
         """
         for f in self.list():
-            if pattern is None or f.fnmatch(pattern):
+            if os.path.isfile(f) and (pattern is None or f.fnmatch(pattern)):
                 yield f

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -66,7 +66,13 @@ def _get_s3_client():
         boto3.Client: An instance of the S3 client.
     """
     if not hasattr(_thread_local, 's3_client'):
-        session = boto3.session.Session()
+        kwargs = {}
+        for k, v in settings.get()['s3'].items():
+            # only pass through keyword arguments that are set to avoid
+            # overriding Boto3's default lookup behavior
+            if v:
+                kwargs[k] = v
+        session = boto3.session.Session(**kwargs)
         _thread_local.s3_client = session.client('s3')
     return _thread_local.s3_client
 

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -41,7 +41,13 @@ class TestCliBasics(BaseCliTest):
     def test_cli_config(self, mock_copytree):
         expected_settings = {
             'stor': {},
-            's3': {},
+            's3': {
+                'aws_access_key_id': '',
+                'aws_secret_access_key': '',
+                'aws_session_token': '',
+                'profile_name': '',
+                'region_name': ''
+            },
             's3:upload': {
                 'segment_size': 8388608,
                 'object_threads': 10,

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -128,9 +128,7 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'b/d'),
                 stor.join(self.test_dir, 'b/abbbc'),
             ]))
-            if isinstance(self, FilesystemIntegrationTest):
-                # should still copy the files even if it does not come from walkfiles
-                assert os.path.exists(stor.join(self.test_dir, 'empty'))
+            assert stor.exists(stor.join(self.test_dir, 'empty'))
             prefix_files = list(self.test_dir.walkfiles('*.sh'))
             self.assertEquals(set(prefix_files), set([
                 stor.join(self.test_dir, 'aabc.sh'),

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -198,14 +198,28 @@ class BaseIntegrationTest(object):
             with stor.open(test_file, mode='wb') as fp:
                 fp.write(BYTE_STRING)
 
-        @skipIf(not six.PY3, "Only tested on py3")
+        # python 2 is absurdly lenient about types
+
+        @skipIf(not six.PY2, "Only tested on py2")
+        def test_write_string_to_binary_py2(self):
+            test_file = self.test_dir / 'test_file.txt'
+            with stor.open(test_file, mode='wb') as fp:
+                fp.write(STRING_STRING)
+
+        @skipIf(not six.PY2, "Only tested on py2")
+        def test_write_bytes_to_text_py2(self):
+            test_file = self.test_dir / 'test_file.txt'
+            with stor.open(test_file, mode='w') as fp:
+                fp.write(BYTE_STRING)
+
+        @skipIf(six.PY2, "Only tested on py3")
         @raises(TypeError)
         def test_write_string_to_binary(self):   # pragma: no cover
             test_file = self.test_dir / 'test_file.txt'
             with stor.open(test_file, mode='wb') as fp:
                 fp.write(STRING_STRING)
 
-        @skipIf(not six.PY3, "Only tested on py3")
+        @skipIf(six.PY2, "Only tested on py3")
         @raises(TypeError)
         def test_write_bytes_to_text(self):   # pragma: no cover
             test_file = self.test_dir / 'test_file.txt'

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -128,7 +128,6 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'b/d'),
                 stor.join(self.test_dir, 'b/abbbc'),
             ]))
-            assert stor.exists(stor.join(self.test_dir, 'empty'))
             prefix_files = list(self.test_dir.walkfiles('*.sh'))
             self.assertEquals(set(prefix_files), set([
                 stor.join(self.test_dir, 'aabc.sh'),
@@ -145,6 +144,7 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'aabc'),
                 stor.join(self.test_dir, 'b/abbbc'),
             ]))
+            # should still *make* an empty directory
             assert stor.exists(stor.join(self.test_dir, 'empty'))
 
         def test_gzip_on_remote(self):

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -107,6 +107,7 @@ class BaseIntegrationTest(object):
                 self.assertTrue(Path('test/.hidden_dir/nested/file2').isfile())
 
         def test_walkfiles(self):
+            from stor.tests.test_integration_posix import FilesystemIntegrationTest
             with NamedTemporaryDirectory(change_dir=True):
                 # Make a dataset with files that will match a particular pattern (*.sh)
                 # and also empty directories that should be ignored when calling walkfiles
@@ -127,6 +128,9 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'b/d'),
                 stor.join(self.test_dir, 'b/abbbc'),
             ]))
+            if isinstance(self, FilesystemIntegrationTest):
+                # should still copy the files even if it does not come from walkfiles
+                assert os.path.exists(stor.join(self.test_dir, 'empty'))
             prefix_files = list(self.test_dir.walkfiles('*.sh'))
             self.assertEquals(set(prefix_files), set([
                 stor.join(self.test_dir, 'aabc.sh'),

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -126,7 +126,6 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'b/c.sh'),
                 stor.join(self.test_dir, 'b/d'),
                 stor.join(self.test_dir, 'b/abbbc'),
-                stor.join(self.test_dir, 'empty'),
             ]))
             prefix_files = list(self.test_dir.walkfiles('*.sh'))
             self.assertEquals(set(prefix_files), set([
@@ -144,6 +143,7 @@ class BaseIntegrationTest(object):
                 stor.join(self.test_dir, 'aabc'),
                 stor.join(self.test_dir, 'b/abbbc'),
             ]))
+            assert stor.exists(stor.join(self.test_dir, 'empty'))
 
         def test_gzip_on_remote(self):
             self._skip_if_filesystem_python3(self.test_dir)

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -198,19 +198,21 @@ class BaseIntegrationTest(object):
             with stor.open(test_file, mode='wb') as fp:
                 fp.write(BYTE_STRING)
 
-        # python 2 is absurdly lenient about types
+        # python 2 is quite lenient about string types on I/O
 
         @skipIf(not six.PY2, "Only tested on py2")
-        def test_write_string_to_binary_py2(self):
+        def test_write_string_to_binary_py2(self):  # pragma: no cover
             test_file = self.test_dir / 'test_file.txt'
             with stor.open(test_file, mode='wb') as fp:
                 fp.write(STRING_STRING)
 
         @skipIf(not six.PY2, "Only tested on py2")
-        def test_write_bytes_to_text_py2(self):
+        def test_write_bytes_to_text_py2(self):  # pragma: no cover
             test_file = self.test_dir / 'test_file.txt'
             with stor.open(test_file, mode='w') as fp:
                 fp.write(BYTE_STRING)
+
+        # whereas Python 3 is quite strict
 
         @skipIf(six.PY2, "Only tested on py3")
         @raises(TypeError)

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -107,7 +107,6 @@ class BaseIntegrationTest(object):
                 self.assertTrue(Path('test/.hidden_dir/nested/file2').isfile())
 
         def test_walkfiles(self):
-            from stor.tests.test_integration_posix import FilesystemIntegrationTest
             with NamedTemporaryDirectory(change_dir=True):
                 # Make a dataset with files that will match a particular pattern (*.sh)
                 # and also empty directories that should be ignored when calling walkfiles

--- a/stor/tests/test_integration_s3.py
+++ b/stor/tests/test_integration_s3.py
@@ -21,7 +21,7 @@ class S3IntegrationTest(BaseIntegrationTest.BaseTestCases):
 
     In order to run the tests, you must have valid AWS S3 credentials set in the
     following environment variables: AWS_TEST_ACCESS_KEY_ID,
-    AWS_TEST_SECRET_ACCESS_KEY (and optionally AWS_DEFUALT_REGION).
+    AWS_TEST_SECRET_ACCESS_KEY (and optionally AWS_DEFAULT_REGION).
     """
     def setUp(self):
         super(S3IntegrationTest, self).setUp()

--- a/stor/tests/test_integration_s3.py
+++ b/stor/tests/test_integration_s3.py
@@ -291,4 +291,5 @@ class S3IntegrationTest(BaseIntegrationTest.BaseTestCases):
         self.assertIn("CompleteMultipartUploadResult", logger.getvalue())
         # Check for multipart download by checking for multiple 206 GET requests
         # to the object
-        self.assertRegexpMatches(logger.getvalue(), '"GET (/stor-test-bucket)?/test/0 HTTP/1.1" 206')
+        self.assertRegexpMatches(logger.getvalue(),
+                                 '"GET (/stor-test-bucket)?/test/0 HTTP/1.1" 206')

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1568,7 +1568,7 @@ class TestSessionSettings(unittest.TestCase):
     def tearDown(self):
         self._clear_s3_cache()
 
-    def _clear_s3_cache(self):
+    def _clear_s3_cache(self):  # pragma: no cover
         if hasattr(s3._thread_local, 's3_client'):
             del s3._thread_local.s3_client
         if hasattr(s3._thread_local, 's3_transfer'):

--- a/stor/tests/test_settings.py
+++ b/stor/tests/test_settings.py
@@ -33,7 +33,13 @@ class TestSettings(unittest.TestCase):
     def test_initialize_default(self):
         expected_settings = {
             'stor': {},
-            's3': {},
+            's3': {
+                'aws_access_key_id': '',
+                'aws_secret_access_key': '',
+                'aws_session_token': '',
+                'profile_name': '',
+                'region_name': ''
+            },
             's3:upload': {
                 'segment_size': 8388608,
                 'object_threads': 10,
@@ -72,13 +78,19 @@ class TestSettings(unittest.TestCase):
             }
         }
         settings._initialize()
-        self.assertEquals(settings._global_settings, expected_settings)
+        assert settings._global_settings == expected_settings
 
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_initialize_w_user_file(self):
         expected_settings = {
             'stor': {},
-            's3': {},
+            's3': {
+                'aws_access_key_id': '',
+                'aws_secret_access_key': '',
+                'aws_session_token': '',
+                'profile_name': '',
+                'region_name': ''
+            },
             's3:upload': {
                 'segment_size': 8388608,
                 'object_threads': 10,

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,5 @@ whitelist_externals = make
                       bash
                       nosetests
 passenv = SWIFT_TEST_USERNAME SWIFT_TEST_PASSWORD OS_TEMP_URL_KEY
-          AWS_TEST_ACCESS_KEY_ID AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID
-          AWS_SECRET_ACCESS_KEY OS_AUTH_URL
+          AWS_TEST_ACCESS_KEY_ID AWS_DEFAULT_REGION
+          AWS_TEST_SECRET_ACCESS_KEY OS_AUTH_URL


### PR DESCRIPTION
@kyleabeauchamp @pkaleta - these changes will allow us to deploy #45 finally.

Changes:

1. Allow overriding settings for S3, so we can explicitly change s3 integration tests to pull from TEST environment variables. (+ add some tests for it)
2. Change `posix.walkfiles()` to check for isfile() so that it's consistent with all other `walkfiles()` methods
3. Allow S3 Integration tests to pass by fixing regex test