### PR TITLE
Ensure we respect locales when reading/writing files

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,16 +4,39 @@ Release Notes
 v1.5.0
 ------
 
-* Auto-create parent directories on the filesystem for ``stor.copy``, ``stor.open``, and ``stor.copytree``.
-* Allow ``stor.copytree`` to work if it targets an empty target directory (removes the other directory first)
-* Fix file read/write behavior in Python 3.
-* Fix S3 integration tests so they are easier to run.
-* Fix inconsistency with ``walkfiles()`` on ``PosixPath`` so that it does not
-  return empty directories (causes a small potential perf hit).
+Summary
+^^^^^^^
+
+Many changes to correctly handle binary and text data in both Python 2 and Python 3. Overall, falls
+back on ``locale.getpreferredencoding(False)`` to handle this behavior correctly.  This change
+should be completely backwards-compatible (any new behaviors would have raised an exception in
+earlier versions of stor).
+
+This release also includes some consistency fixes for certain rare edge cases relating to empty or
+non/existent files and directories.
+
+API additions
+^^^^^^^^^^^^^
+
 * Add ``encoding`` keyword argument (supported only in Python 3) to ``open()`` and ``OBSFile``.
   This keyword arg overrides default encoding, otherwise, ``encoding`` for text data is pulled from
   ``locale.getpreferredencoding(False)`` the same as Python 3.
+* File reading and writing now works in Python 3 in both text and binary modes.
 
+Consistency Fixes
+^^^^^^^^^^^^^^^^^
+
+* Fix inconsistency with ``walkfiles()`` on ``PosixPath`` so that it does not
+  return empty directories (causes a small potential perf hit).
+* Auto-create parent directories on the filesystem for ``stor.copy``, ``stor.open``, and ``stor.copytree``.
+* Allow ``stor.copytree`` to work if it targets an empty target directory (removes the other directory first)
+* Fix S3 integration tests so they are easier to run.
+
+Deprecations
+^^^^^^^^^^^^
+
+* Using text data with ``read_object()`` and ``write_object()`` is deprecated. These functions
+  ought to only work with ``bytes`` (and will have unexpected behavior otherwise).
 
 v1.4.6
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.5.0
+v1.5.1
 ------
 
 Summary
@@ -37,6 +37,8 @@ Deprecations
 
 * Using text data with ``read_object()`` and ``write_object()`` is deprecated. These functions
   ought to only work with ``bytes`` (and will have unexpected behavior otherwise).
+
+(v1.5.0 was a premature release and was removed from PyPI)
 
 v1.4.6
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,9 @@ v1.5.0
 * Fix S3 integration tests so they are easier to run.
 * Fix inconsistency with ``walkfiles()`` on ``PosixPath`` so that it does not
   return empty directories (causes a small potential perf hit).
+* Add ``encoding`` keyword argument (supported only in Python 3) to ``open()`` and ``OBSFile``.
+  This keyword arg overrides default encoding, otherwise, ``encoding`` for text data is pulled from
+  ``locale.getpreferredencoding(False)`` the same as Python 3.
 
 
 v1.4.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ freezegun==0.3.6
 mock==1.3.0
 nose==1.3.7
 testfixtures==4.7.0
-coverage==4.0.3
-pytest==3.2.2
-pytest-cov==2.2.1
+coverage==4.4.1
+pytest==3.2.3
+pytest-cov==2.5.1

--- a/stor/base.py
+++ b/stor/base.py
@@ -11,7 +11,6 @@ import warnings
 from six.moves import builtins
 from six import text_type
 from six import string_types
-from six import PY2
 from six import PY3
 
 from stor import utils

--- a/stor/base.py
+++ b/stor/base.py
@@ -11,6 +11,7 @@ import warnings
 from six.moves import builtins
 from six import text_type
 from six import string_types
+from six import PY2
 from six import PY3
 
 from stor import utils
@@ -259,7 +260,16 @@ class Path(text_type):
         """
         return self.path_class(self.path_module.join(self, *others))
 
-    def open(self, **kwargs):
+    def open(self, *args, **kwargs):
+        """Open a file-like object.
+
+        The only cross-compatible arguments for this function are listed below.
+
+        Args:
+            mode (str): first positional arg, mode of file descriptor
+            encoding (str): text encoding to use (Python 3 only)
+        """
+
         raise NotImplementedError
 
     def list(self, *args, **kwargs):

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -168,10 +168,9 @@ def _get_pwd(service=None):
     or all services if none specified.
     """
     def to_text(data):
-        if six.PY2:
-            return data.decode(locale.getpreferredencoding(False))
-        else:
-            return data
+        if six.PY2:  # pragma: no cover
+            data = data.decode(locale.getpreferredencoding(False))
+        return data
 
     parser = _get_env()
     if service:

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -167,12 +167,12 @@ def _get_pwd(service=None):
     Returns the present working directory for the given service,
     or all services if none specified.
     """
-    if six.PY2:
-        # have to hack around text/bytes here because Python 2
-        to_text = lambda x: x.decode(locale.getpreferredencoding(False))
-    else:
-        to_text = lambda x: x
-    # encoding = locale.getpreferredencoding(False)
+    def to_text(data):
+        if six.PY2:
+            return data.decode(locale.getpreferredencoding(False))
+        else:
+            return data
+
     parser = _get_env()
     if service:
         try:

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -1,3 +1,4 @@
+import locale
 import posixpath
 import sys
 
@@ -127,13 +128,22 @@ class OBSPath(Path):
         return self.path_class(self.drive + normed)
 
     def read_object(self):
+        """Reads an individual object from OBS.
+
+        Returns:
+            bytes: the raw bytes from the object on OBS.
+        """
         raise NotImplementedError
 
     def write_object(self, content):
-        """Writes an individual object."""
+        """Writes an individual object.
+
+        Args:
+            content (bytes): raw bytes to write to OBS
+        """
         raise NotImplementedError
 
-    def open(self, mode='r'):
+    def open(self, mode='r', encoding=None):
         """
         Opens a OBSFile that can be read or written to and is uploaded to
         the remote service.
@@ -252,7 +262,7 @@ class OBSFile(object):
     _WRITE_MODES = ('w', 'wb')
     _VALID_MODES = _READ_MODES + _WRITE_MODES
 
-    def __init__(self, pth, mode='r', **kwargs):
+    def __init__(self, pth, mode='r', encoding=None, **kwargs):
         """Initializes a file object
 
         Args:
@@ -261,12 +271,20 @@ class OBSFile(object):
             mode (str): The mode of the resource. Can be "r" and "rb" for
                 reading the resource and "w" and "wb" for writing the
                 resource.
+            encoding (str): the text encoding to use on read/write, defaults to
+                ``locale.getpreferredencoding(False)`` if not set. We *strongly* encourage you to
+                use binary mode OR explicitly set an encoding when reading/writing text (because
+                writers from different computers may store data on OBS in different ways).
+                Python 3 only.
         """
         if mode not in self._VALID_MODES:
             raise ValueError('invalid mode for file: %r' % mode)
+        if six.PY2 and encoding:  # pragma: no cover
+            raise TypeError('encoding not supported in Python 2')
         self._path = pth
         self.mode = mode
         self._kwargs = kwargs
+        self.encoding = encoding or locale.getpreferredencoding(False)
 
     def __enter__(self):
         if self.closed:
@@ -292,11 +310,10 @@ class OBSFile(object):
     @cached_property
     def _buffer(self):
         "Cached buffer of data read from or to be written to Object Storage"
-        if self.mode in ('r', 'rb'):
-            try:  # Catch possible bytes / str issues on py3k
-                return self.stream_cls(self._path.read_object())
-            except TypeError:
-                return self.stream_cls(self._path.read_object().decode("utf-8"))
+        if self.mode == 'r':
+            return self.stream_cls(self._path.read_object().decode(self.encoding))
+        if self.mode == 'rb':
+            return self.stream_cls(self._path.read_object())
         elif self.mode in ('w', 'wb'):
             return self.stream_cls()
         else:
@@ -340,5 +357,8 @@ class OBSFile(object):
             raise TypeError("File must be in modes %s to 'flush'" %
                             (self._WRITE_MODES,))
         if self._buffer.tell():
-            self._path.write_object(self._buffer.getvalue(),
-                                    **self._kwargs)
+            if self.mode == 'w':
+                self._path.write_object(self._buffer.getvalue().encode(self.encoding))
+            else:
+                self._path.write_object(self._buffer.getvalue(),
+                                        **self._kwargs)

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -40,6 +40,7 @@ import logging
 import os
 import tempfile
 import threading
+import warnings
 
 import six
 from six.moves.urllib import parse
@@ -595,7 +596,10 @@ class SwiftPath(OBSPath):
     @_swift_retry(exceptions=(NotFoundError, UnavailableError,
                               InconsistentDownloadError, UnauthorizedError))
     def read_object(self):
-        """Reads an individual object.
+        """Reads an individual object from OBS.
+
+        Returns:
+            bytes: the raw bytes from the object on OBS.
 
         This method retries ``num_retries`` times if swift is unavailable or if
         the object is not found. View
@@ -672,10 +676,12 @@ class SwiftPath(OBSPath):
         `SwiftPath.upload`.
 
         Args:
-            content (str): The content of the object
+            content (bytes): raw bytes to write to OBS
             **swift_upload_args: Keyword arguments to pass to
                 `SwiftPath.upload`
         """
+        if not isinstance(content, bytes):
+            warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
         mode = 'wb' if type(content) == bytes else 'wt'
         with tempfile.NamedTemporaryFile(mode=mode) as fp:
             fp.write(content)
@@ -683,7 +689,7 @@ class SwiftPath(OBSPath):
             suo = OBSUploadObject(fp.name, object_name=self.resource)
             return self.upload([suo], **swift_upload_args)
 
-    def open(self, mode='r', swift_upload_options=None):
+    def open(self, mode='r', encoding=None, swift_upload_options=None):
         """Opens a `SwiftFile` that can be read or written to.
 
         For examples of reading and writing opened objects, view
@@ -692,6 +698,8 @@ class SwiftPath(OBSPath):
         Args:
             mode (str): The mode of object IO. Currently supports reading
                 ("r" or "rb") and writing ("w", "wb")
+            encoding (str): text encoding to use. Defaults to
+                ``locale.getpreferredencoding(False)`` (Python 3 only)
             swift_upload_options (dict): DEPRECATED (use `stor.settings.use()`
                 instead). A dictionary of arguments that will be
                 passed as keyword args to `SwiftPath.upload` if any writes
@@ -704,7 +712,7 @@ class SwiftPath(OBSPath):
             SwiftError: A swift client error occurred.
         """
         swift_upload_options = swift_upload_options or {}
-        return SwiftFile(self, mode=mode, **swift_upload_options)
+        return SwiftFile(self, mode=mode, encoding=encoding, **swift_upload_options)
 
     @_swift_retry(exceptions=(ConditionNotMetError, UnavailableError))
     def list(self,

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -680,7 +680,7 @@ class SwiftPath(OBSPath):
             **swift_upload_args: Keyword arguments to pass to
                 `SwiftPath.upload`
         """
-        if not isinstance(content, bytes):
+        if not isinstance(content, bytes):  # pragma: no cover
             warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
         mode = 'wb' if type(content) == bytes else 'wt'
         with tempfile.NamedTemporaryFile(mode=mode) as fp:

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -458,14 +458,14 @@ class TestWalkfiles(BaseCliTest):
 class TestCat(BaseCliTest):
     @mock.patch.object(S3Path, 'read_object', autospec=True)
     def test_cat_s3(self, mock_read):
-        mock_read.return_value = 'hello world\n'
+        mock_read.return_value = b'hello world\n'
         self.parse_args('stor cat s3://test/file')
         self.assertEquals(sys.stdout.getvalue(), 'hello world\n')
         mock_read.assert_called_once_with(S3Path('s3://test/file'))
 
     @mock.patch.object(SwiftPath, 'read_object', autospec=True)
     def test_cat_swift(self, mock_read):
-        mock_read.return_value = 'hello world'
+        mock_read.return_value = b'hello world'
         self.parse_args('stor cat swift://some/test/file')
         self.assertEquals(sys.stdout.getvalue(), 'hello world\n')
         mock_read.assert_called_once_with(SwiftPath('swift://some/test/file'))

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import contextlib
 import gzip
 import os
 import unittest
@@ -7,7 +6,6 @@ import six
 from nose.tools import raises
 from unittest import skipIf
 
-import mock
 import pytest
 
 import stor

--- a/stor/tests/test_integration.py
+++ b/stor/tests/test_integration.py
@@ -280,36 +280,9 @@ class BaseIntegrationTest(object):
                     result = fp.read()
 
         @skipIf(not six.PY2, 'only check for encoding typeerrors on python 2')
-        def test_custom_encoding_py2(self):
+        def test_encoding_typeerror_py2(self):
             test_file = self.test_dir / 'test_file.txt'
             with pytest.raises(TypeError, regex='encoding'):
                 stor.open(test_file, mode='r', encoding='utf-8')
             with pytest.raises(TypeError, regex='encoding'):
                 stor.Path(test_file).open(mode='r', encoding='utf-8')
-
-            @contextlib.contextmanager
-            def temp_encoding(encoding):
-                import sys
-                original_encoding = sys.getdefaultencoding()
-
-                reload(sys)
-                try:
-                    sys.setdefaultencoding(encoding)
-                    with mock.patch('locale.getpreferredencoding') as mocker:
-                        mocker.return_value = original_encoding
-                        yield
-                finally:
-                    sys.setdefaultencoding(original_encoding)
-
-            with temp_encoding('utf-16'):
-                with stor.open(test_file, mode='w') as fp:
-                    fp.write(STRING_STRING)
-
-                with stor.open(test_file, mode='r') as fp:
-                    result = fp.read()
-                assert result == STRING_STRING
-
-            with temp_encoding('utf-8'):
-                with pytest.raises(UnicodeDecodeError):
-                    with stor.open(test_file, mode='r') as fp:
-                        result = fp.read()

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 install_command = pip install {opts} {packages}
 indexserver =
     default = https://pypi.python.org/simple/
-envlist = py27,py35
+envlist = py27,py36
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
@kyleabeauchamp @pkaleta - the implementation that I (accidentally) allowed to be deployed to PyPI as v1.5.0 forces all text to be utf-8 on OBS, which probably isn't the behavior we want to show (works on Python 3, but only if utf-8 is the encoding).

I still need to fix a couple failing tests, but I wanted to get feedback on whether this makes sense and/or is the right way to do it.

This PR:

1. adds an `encoding` argument (only for Python3 ) that allows explicitly setting encoding
2. falls back to `locale.getpreferredencoding(False)` if encoding not set
3. Confirms that `write_object()` and `read_object()` should handle bytes only. (and adds a deprecation warning for the future)