### PR TITLE
Fix up python 3-compatible stor for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PACKAGE_NAME=stor
 TEST_OUTPUT?=nosetests.xml
 PIP_INDEX_URL=https://pypi.python.org/simple/
+PYTHON?=$(shell which python)
 
 ifdef TOX_ENV
 	TOX_ENV_FLAG := -e $(TOX_ENV)
@@ -23,7 +24,8 @@ WITH_PBR=$(WITH_VENV) PBR_REQUIREMENTS_FILES=requirements-pbr.txt
 venv: $(VENV_ACTIVATE)
 
 $(VENV_ACTIVATE): requirements*.txt
-	test -f $@ || virtualenv $(VENV_DIR)
+	test -f $@ || virtualenv --python=$(PYTHON) $(VENV_DIR)
+	$(WITH_VENV) echo "Within venv, running $$(python --version)"
 	$(WITH_VENV) pip install -r requirements-setup.txt --index-url=${PIP_INDEX_URL}
 	$(WITH_VENV) pip install -e . --index-url=${PIP_INDEX_URL}
 	$(WITH_VENV) pip install -r requirements-dev.txt  --index-url=${PIP_INDEX_URL}
@@ -49,7 +51,7 @@ endif
 
 .PHONY: clean
 clean:
-	python setup.py clean
+	$(PYTHON) setup.py clean
 	rm -rf build/
 	rm -rf dist/
 	rm -rf *.egg*/
@@ -128,4 +130,4 @@ version:
 
 .PHONY: fullname
 fullname:
-	python setup.py --fullname
+	$(PYTHON) setup.py --fullname

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,7 +13,7 @@ should be completely backwards-compatible (any new behaviors would have raised a
 earlier versions of stor).
 
 This release also includes some consistency fixes for certain rare edge cases relating to empty or
-non/existent files and directories.
+non/existent files and directories. Drops testing for Python 3.3.
 
 API additions
 ^^^^^^^^^^^^^
@@ -37,6 +37,8 @@ Deprecations
 
 * Using text data with ``read_object()`` and ``write_object()`` is deprecated. These functions
   ought to only work with ``bytes`` (and will have unexpected behavior otherwise).
+* Python 3.3 is no longer tested in the test suite (but we still think stor
+  will run correctly in Python 3.3 - but this was never explicitly supported)
 
 (v1.5.0 was a premature release and was removed from PyPI)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Development Status :: 5 - Production/Stable
     Operating System :: OS Independent
 

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -7,6 +7,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import tempfile
 import threading
+import warnings
 
 import boto3
 from boto3 import exceptions as boto3_exceptions
@@ -497,6 +498,8 @@ class S3Path(OBSPath):
         Args:
             content (bytes): raw bytes to write to OBS
         """
+        if not isinstance(content, bytes):  # pragma: no cover
+            warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
         mode = 'wb' if isinstance(content, bytes) else 'w'
         with tempfile.NamedTemporaryFile(mode) as fp:
             fp.write(content)

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -129,7 +129,7 @@ class TestGetS3Client(S3TestCase):
     def test_get_s3_client_none(self):
         self.disable_get_s3_client_mock()
         client = s3._get_s3_client()
-        self.mock_s3_session.assert_called_once_with()
+        self.assertEqual(len(self.mock_s3_session.call_args_list), 1)
         self.mock_s3_session.return_value.client.assert_called_once_with('s3')
         self.assertEquals(client, self.mock_s3_session.return_value.client.return_value)
 
@@ -348,7 +348,7 @@ class TestList(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_list_w_use_manifest(self, mock_stream):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list = self.mock_s3_iterator
         mock_list.__iter__.return_value = [{
@@ -370,7 +370,7 @@ class TestList(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_list_w_use_manifest_validation_err(self, mock_stream):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list = self.mock_s3_iterator
         mock_list.__iter__.return_value = [{
@@ -387,7 +387,7 @@ class TestList(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_list_w_condition_and_use_manifest(self, mock_stream):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list = self.mock_s3_iterator
         mock_list.__iter__.return_value = [{
@@ -1228,7 +1228,7 @@ class TestDownload(S3TestCase):
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_download_w_use_manifest(self, mock_stream, mock_list, mock_getsize,
                                      mock_make_dest_dir):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list.return_value = [
             S3Path('s3://bucket/my/obj1'),
@@ -1244,7 +1244,7 @@ class TestDownload(S3TestCase):
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_download_w_use_manifest_validation_err(self, mock_stream, mock_list, mock_getsize,
                                                     mock_make_dest_dir):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list.return_value = [
             S3Path('s3://bucket/my/obj1'),
@@ -1259,7 +1259,7 @@ class TestDownload(S3TestCase):
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_download_w_condition_and_use_manifest(self, mock_stream, mock_list, mock_getsize,
                                                    mock_make_dest_dir):
-        mock_stream.read.return_value = 'my/obj1\nmy/obj2\nmy/obj3\n'
+        mock_stream.read.return_value = b'my/obj1\nmy/obj2\nmy/obj3\n'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         mock_list.return_value = [
             S3Path('s3://bucket/my/obj1'),
@@ -1402,7 +1402,7 @@ class TestS3File(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_invalid_flush_mode(self, mock_stream):
-        mock_stream.read.return_value = 'data'
+        mock_stream.read.return_value = b'data'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         s3_p = S3Path('s3://bucket/key/obj')
         obj = s3_p.open()
@@ -1416,7 +1416,7 @@ class TestS3File(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_context_manager_on_closed_file(self, mock_stream):
-        mock_stream.read.return_value = 'data'
+        mock_stream.read.return_value = b'data'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         s3_p = S3Path('s3://bucket/key/obj')
         obj = s3_p.open()
@@ -1441,7 +1441,7 @@ class TestS3File(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_read_on_closed_file(self, mock_stream):
-        mock_stream.read.return_value = 'data'
+        mock_stream.read.return_value = b'data'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
         s3_p = S3Path('s3://bucket/key/obj')
         obj = s3_p.open()
@@ -1457,7 +1457,7 @@ class TestS3File(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_read_success(self, mock_stream):
-        mock_stream.read.return_value = 'data'
+        mock_stream.read.return_value = b'data'
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
 
         s3_p = S3Path('s3://bucket/key/obj')
@@ -1465,7 +1465,7 @@ class TestS3File(S3TestCase):
 
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_iterating_over_files(self, mock_stream):
-        data = '''\
+        data = b'''\
 line1
 line2
 line3
@@ -1475,9 +1475,9 @@ line4
         self.mock_s3.get_object.return_value = {'Body': mock_stream}
 
         s3_p = S3Path('s3://bucket/key/obj')
-        self.assertEquals(s3_p.open().read(), data)
+        self.assertEquals(s3_p.open().read(), data.decode('ascii'))
         self.assertEquals(s3_p.open().readlines(),
-                          [l + '\n' for l in data.split('\n')][:-1])
+                          [l + '\n' for l in data.decode('ascii').split('\n')][:-1])
         for i, line in enumerate(s3_p.open(), 1):
             self.assertEqual(line, 'line%d\n' % i)
 
@@ -1505,9 +1505,9 @@ line4
     def test_write_multiple_flush_multiple_upload(self, mock_sleep):
         mock_upload = self.mock_s3_transfer.upload_file
         s3_p = S3Path('s3://bucket/key/obj')
-        with NamedTemporaryFile('w', delete=False) as ntf1,\
-                NamedTemporaryFile('w', delete=False) as ntf2,\
-                NamedTemporaryFile('w', delete=False) as ntf3:
+        with NamedTemporaryFile('wb', delete=False) as ntf1,\
+                NamedTemporaryFile('wb', delete=False) as ntf2,\
+                NamedTemporaryFile('wb', delete=False) as ntf3:
             with mock.patch('tempfile.NamedTemporaryFile', autospec=True) as ntf:
                 ntf.side_effect = [ntf1, ntf2, ntf3]
                 with s3_p.open(mode='w') as obj:
@@ -1525,11 +1525,11 @@ line4
                 self.assertTrue(u1[1]['key'] == s3_p.resource)
                 self.assertTrue(u2[1]['key'] == s3_p.resource)
                 self.assertTrue(u3[1]['key'] == s3_p.resource)
-                self.assertEqual(open(ntf1.name).read(), 'hello')
-                self.assertEqual(open(ntf2.name).read(), 'hello world')
+                self.assertEqual(open(ntf1.name, 'rb').read(), b'hello')
+                self.assertEqual(open(ntf2.name, 'rb').read(), b'hello world')
                 # third call happens because we don't care about checking for
                 # additional file change
-                self.assertEqual(open(ntf3.name).read(), 'hello world')
+                self.assertEqual(open(ntf3.name, 'rb').read(), b'hello world')
 
     @mock.patch('time.sleep', autospec=True)
     def test_close_no_writes(self, mock_sleep):


### PR DESCRIPTION
### Changes

1. Fix up test case mocks to use bytes for body data when they ought to do that
2. Change virtualenv generation so it actually respects the version that travis has sourced. (e.g., on prior builds it'd list out `python 3.6` as the global python, but then virtualenv would go pick `python2` by default when generating a venv).
3. Remove Python 3.3 Travis test because sphinx no longer supports it.

### Background

The (now-removed-from-PyPI) stor v1.5.0 had a bug in it as described in #54.  In fixing that bug, we changed to a more explicit way of handling read/write buffers (i.e., actually using type information from read/write) and using correct locale-encoding for OBS.  This introduced some additional errors, which were caught in the internal deploy pipeline and so that version was never released.

### How were the bugs missed?

Turns out Travis was not running Python 3 tests!  Also I assumed `make test` would pass locally if Travis was passing.

### Steps to prevent this in the future

- [x] ensure Travis runs python 3 tests
- [ ] make it easier to run arbitrary revisions with integration test (will leave for follow up PR)

### How was this tested

* ran `make test` without credentials set
* ran `make test` with test credentials for S3 and Swift set
* Travis tests passed
* manually played around in the shell briefly

Opening PR early so we can see if it'll pass on Travis.