### PR TITLE
Set universal flag now that we are python2/3 compatible

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,10 +1,11 @@
 Release Notes
 =============
 
-Latest
+v1.5.2
 ------
 
-* Build universal wheels by default
+* Build universal wheels for both Python 2 and Python 3.
+  (no actual code changes)
 
 v1.5.1
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Latest
+------
+
+* Build universal wheels by default
+
 v1.5.1
 ------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,5 +50,5 @@ exclude = stor/third_party/*
 skip_authors = true
 skip_changelog = true
 
-[global]
-test_suite = nose.collector
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Right now we only build `py2-none-any.whl`.  Now that we are python 3 compatible (for real!), we should put up `py2.py3-none-any.whl` so Python 3 can benefit from wheels too!