### PR TITLE
Expose stor.utils.is_obs_path

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v1.5.3
+------
+
+* Hoist ``stor.utils.is_obs_path`` --> ``stor.is_obs_path``
+
 v1.5.2
 ------
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -26,6 +26,7 @@ from stor.utils import copy
 from stor.utils import copytree
 from stor.utils import is_filesystem_path
 from stor.utils import is_swift_path
+from stor.utils import is_obs_path
 from stor.utils import NamedTemporaryDirectory
 from stor.base import Path
 from stor import settings
@@ -138,5 +139,6 @@ __all__ = [
     'walkfiles',
     'is_filesystem_path',
     'is_swift_path',
+    'is_obs_path',
     'NamedTemporaryDirectory',
 ]


### PR DESCRIPTION
Really simple - makes `is_obs_path` part of top-level API of stor (this was an omission from earlier).

@wesleykendall or @kyleabeauchamp if you have a sec