### PR TITLE
Swiftstack to s3 path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ teardown:
 
 .PHONY: lint
 lint: venv
-	$(WITH_VENV) flake8 -v $(PACKAGE_NAME)/
+	$(WITH_VENV) flake8 $(PACKAGE_NAME)/
 
 .PHONY: unit-test
 unit-test: venv

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -1,0 +1,5 @@
+SwiftStack Extension
+--------------------
+
+.. automodule:: stor.extensions.swiftstack
+    :members:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 v1.6.0
 ------
 
+* Add ``stor.extensions.swiftstack`` module for translating swift paths to s3.
+* Add ``convert-swiftstack`` cli tool.
 * Add ``to_url()`` method on Path and ``url`` cli method to translate swift and s3 paths to HTTP paths.
 * Add ``stor.makedirs_p(path, mode=0o777)`` to cross-compatible API. This does
   nothing on OBS-paths (just there for convenience).

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,11 +4,19 @@ Release Notes
 v1.6.0
 ------
 
-* Add ``stor.extensions.swiftstack`` module for translating swift paths to s3.
-* Add ``convert-swiftstack`` cli tool.
-* Add ``to_url()`` method on Path and ``url`` cli method to translate swift and s3 paths to HTTP paths.
+API additions
+^^^^^^^^^^^^^
+
+* Add `stor.extensions.swiftstack` module for translating swift paths to s3.
+* Add ``OBSPath.to_url()`` method to translate swift and s3 paths to HTTP paths.
 * Add ``stor.makedirs_p(path, mode=0o777)`` to cross-compatible API. This does
   nothing on OBS-paths (just there for convenience).
+
+CLI additions
+^^^^^^^^^^^^^
+
+* ``stor url <path>`` to translate swift and s3 paths to HTTP paths.
+* ``stor convert-swiftstack [--bucket] <path>`` cli tool to convert s3 <-> swiftstack paths.
 
 v1.5.2
 ------

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -14,6 +14,7 @@ Table of Contents
    windows
    testing
    settings
+   extensions
    contributing
    roadmap
    release_notes

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -278,11 +278,14 @@ def _to_url(path):
 def _convert_swiftstack(path, bucket=None):
     path = stor.Path(path)
     if utils.is_swift_path(path):
+        if not bucket:
+            # TODO (jtratner): print help here
+            raise ValueError('--bucket is required for swift paths')
         return swiftstack.swift_to_s3(path, bucket=bucket)
     elif utils.is_s3_path(path):
         return swiftstack.s3_to_swift(path)
     else:
-        raise ValueError('invalid path for conversion: %r' % path)
+        raise ValueError("invalid path for conversion: '%s'" % path)
 
 
 def create_parser():

--- a/stor/extensions/swiftstack.py
+++ b/stor/extensions/swiftstack.py
@@ -1,0 +1,44 @@
+"""
+SwiftStack Utilities
+====================
+
+Utilities specific to SwiftStack's implementation of Openstack Swift.
+
+Use this module to translate swift paths to S3 paths.
+"""
+import stor
+import hashlib
+
+
+def swift_to_s3(swift_path, bucket):
+    """SwiftStack Swift Path to S3 Cloud-Shunt Path
+
+    Args:
+        swift_path (str|Path): path to convert
+        bucket (str): name of S3 bucket
+    Returns:
+        S3Path: the converted path
+
+    See https://www.swiftstack.com/docs/admin/cluster_management/cloud_sync.html#swift-object-representation-in-s3 for details
+    """  # nopep8
+    if not bucket:
+        raise TypeError('bucket is required')
+    swift_path = stor.Path(swift_path)
+    h = hashlib.md5((u'%s/%s' % (swift_path.tenant, swift_path.container)
+                     ).encode("utf8")).hexdigest()
+    prefix = hex(int(h, 16) % 16**6).lstrip('0x').rstrip('L')
+    pth = stor.join('s3://%s' % bucket, prefix, swift_path.tenant, swift_path.container)
+    if swift_path.resource:
+        pth = stor.join(pth, swift_path.resource)
+    return pth
+
+
+def s3_to_swift(s3_path):
+    """S3 Cloud-Sync style path to SwiftStack Path
+
+    Args:
+        s3_path (str|Path): path to convert
+    Returns:
+        SwiftPath: the converted path
+    """
+    return stor.join('swift://', *stor.Path(s3_path).resource.split('/')[1:])

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -237,6 +237,10 @@ class OBSPath(Path):
         """Upload a list of files and directories to a directory."""
         raise NotImplementedError
 
+    def to_url(self):
+        """Get HTTPS URL for given path"""
+        raise NotImplementedError
+
 
 class OBSFile(object):
     """

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -52,6 +52,11 @@ class BaseCliTest(test.S3TestCase, test.SwiftTestCase):
 
 
 class TestCliTestUtils(BaseCliTest):
+    def test_no_exit_status(self):
+        with six.assertRaisesRegex(self, AssertionError, 'SystemExit'):
+            with self.assertOutputMatches(exit_status='1'):
+                pass
+
     def test_stdout_matching(self):
         with six.assertRaisesRegex(self, AssertionError, 'stdout'):
             with self.assertOutputMatches(stdout=None):

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -74,7 +74,6 @@ class TestCliTestUtils(BaseCliTest):
                 print('blah', file=sys.stderr)
 
 
-
 class TestCliBasics(BaseCliTest):
     @mock.patch.object(S3Path, 'list', autospec=True)
     def test_cli_error(self, mock_list):

--- a/stor/tests/test_extensions_swiftstack.py
+++ b/stor/tests/test_extensions_swiftstack.py
@@ -6,8 +6,8 @@ from stor.extensions import swiftstack
 
 
 class TestSwiftStackExtensions(BaseCliTest):
-    swift_path = "swift://AUTH_seq_upload_prod/D00576"
-    s3_path = "s3://ex-bucket/a9bf76/AUTH_seq_upload_prod/D00576"
+    swift_path = 'swift://AUTH_seq_upload_prod/D00576'
+    s3_path = 's3://ex-bucket/a9bf76/AUTH_seq_upload_prod/D00576'
 
     def test_s3_to_swift_cli(self):
         self.parse_args('stor convert-swiftstack %s --bucket ex-bucket' % self.swift_path)
@@ -17,12 +17,16 @@ class TestSwiftStackExtensions(BaseCliTest):
         with self.assertOutputMatches(exit_status='1', stderr='bucket'):
             self.parse_args('stor convert-swiftstack %s' % self.swift_path)
 
+        with self.assertRaisesRegexp(TypeError, 'bucket is required'):
+            swiftstack.swift_to_s3(self.swift_path, None)
+
     def test_filesystem_path_errors(self):
         with self.assertOutputMatches(exit_status='1', stderr="invalid path.* '/test/path'"):
             self.parse_args('stor convert-swiftstack /test/path')
 
     def test_swift_to_s3(self):
-        assert str(swiftstack.swift_to_s3(self.swift_path, "ex-bucket")) == self.s3_path
+        assert str(swiftstack.swift_to_s3(self.swift_path, 'ex-bucket')) == self.s3_path
+        assert str(swiftstack.swift_to_s3(self.swift_path + '/some/object', 'ex-bucket')) == self.s3_path + '/some/object'
 
     def test_s3_to_swift(self):
         assert str(swiftstack.s3_to_swift(self.s3_path)) == self.swift_path

--- a/stor/tests/test_extensions_swiftstack.py
+++ b/stor/tests/test_extensions_swiftstack.py
@@ -26,7 +26,8 @@ class TestSwiftStackExtensions(BaseCliTest):
 
     def test_swift_to_s3(self):
         assert str(swiftstack.swift_to_s3(self.swift_path, 'ex-bucket')) == self.s3_path
-        assert str(swiftstack.swift_to_s3(self.swift_path + '/some/object', 'ex-bucket')) == self.s3_path + '/some/object'
+        assert (str(swiftstack.swift_to_s3(self.swift_path + '/some/object', 'ex-bucket')) ==
+                self.s3_path + '/some/object')
 
     def test_s3_to_swift(self):
         assert str(swiftstack.s3_to_swift(self.s3_path)) == self.swift_path

--- a/stor/tests/test_extensions_swiftstack.py
+++ b/stor/tests/test_extensions_swiftstack.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+
+import mock
+import six
+
+from stor import cli
+from stor.extensions import swiftstack
+
+
+@mock.patch('sys.stdout', new=six.StringIO())
+class SwiftStackExtensions(unittest.TestCase):
+    swift_path = "swift://AUTH_seq_upload_prod/D00576"
+    s3_path = "s3://ex-bucket/a9bf76/AUTH_seq_upload_prod/D00576"
+
+    def test_cli(self):
+        with mock.patch.object(
+            sys, 'argv',
+            ['stor', 'convert-swiftstack', self.swift_path, '--bucket', 'ex-bucket']
+        ):
+            cli.main()
+        self.assertEqual(sys.stdout.getvalue(), self.s3_path + '\n')
+
+        with self.assertRaisesRegexp(TypeError, 'bucket is required'):
+            with mock.patch.object(
+                sys, 'argv',
+                ['stor', 'convert-swiftstack', self.swift_path]
+            ):
+                cli.main()
+
+    def test_swift_to_s3(self):
+        assert str(swiftstack.swift_to_s3(self.swift_path, "ex-bucket")) == self.s3_path
+
+    def test_s3_to_swift(self):
+        assert str(swiftstack.s3_to_swift(self.s3_path)) == self.swift_path
+        assert cli._convert_swiftstack(self.s3_path, None) == self.swift_path


### PR DESCRIPTION
* Add ``stor.extensions.swiftstack`` module for translating swift paths to s3.
* Add ``convert-swiftstack`` cli tool.

See https://www.swiftstack.com/docs/admin/cluster_management/cloud_sync.html#swift-object-representation-in-s3 for more

```
›› stor convert-swiftstack --bucket=mybucket swift://AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv
s3://mybucket/76f1d2/AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv
```

```
›› stor convert-swiftstack s3://mybucket/76f1d2/AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv
swift://AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv
```

cc @kyleabeauchamp @kristjaneerik 