### PR TITLE
Raise informative error on GETs from objects in Glacier

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,0 +1,6 @@
+Stor Python Exceptions
+======================
+
+.. automodule:: stor.exceptions
+    :members:
+    :member-order: bysource

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+Latest
+------
+
+API Changes
+^^^^^^^^^^^
+
+* GETs on unrestored Glacier objects raise an ``ObjectInColdStorageError``
+  rather than an ``UnauthorizedError``.
+
 v1.6.0
 ------
 

--- a/docs/swift.rst
+++ b/docs/swift.rst
@@ -90,26 +90,6 @@ SwiftUploadObject
 .. autoclass:: SwiftUploadObject
   :members:
 
-
-Exceptions
-----------
-
-.. autoexception:: SwiftError
-
-.. autoexception:: NotFoundError
-
-.. autoexception:: UnavailableError
-
-.. autoexception:: FailedUploadError
-
-.. autoexception:: UnauthorizedError
-
-.. autoexception:: ConfigurationError
-
-.. autoexception:: ConditionNotMetError
-
-.. autoexception:: ConflictError
-
 Utilities
 ---------
 

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -12,6 +12,7 @@ Table of Contents
    s3
    posix
    windows
+   exceptions
    testing
    settings
    contributing

--- a/stor/exceptions.py
+++ b/stor/exceptions.py
@@ -10,9 +10,18 @@ class RemoteError(Exception):
 
     The 'caught_exception' attribute of the exception must be examined in order
     to inspect the exception thrown by the swift or S3 service. A swift exception
-    can either be a ``SwiftError`` (thrown by ``swiftclient.service``) or a
-    ``ClientError`` (thrown by ``swiftclient.client``). A S3 exception can be
-    a ``ClientError`` (thrown by ``botocore.client``).
+
+    Swift has two types of caught exceptions:
+
+    * ``SwiftError`` (thrown by ``swiftclient.service``)
+    * ``ClientError`` (thrown by ``swiftclient.client``)
+
+    S3 raises:
+
+    * ``ClientError`` (thrown by ``botocore.client``).
+
+    Attributes:
+        caught_exception (Exception): the underlying exception that was raised from service.
     """
     def __init__(self, message, caught_exception=None):
         super(RemoteError, self).__init__(message)
@@ -22,6 +31,18 @@ class RemoteError(Exception):
 class NotFoundError(RemoteError):
     """Thrown when a 404 response is returned."""
     pass
+
+
+class ObjectInColdStorageError(RemoteError):
+    """Thrown when a 403 is returned from S3/SwiftStack because backing data is on Glacier.
+
+    Note:
+        We don't want to retry on this
+        one, because the object will always be in cold storage.
+        See AWS `S3 Rest API GET`_ spec for more details.
+
+    .. _S3 Rest API GET: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
+    """
 
 
 class UnauthorizedError(RemoteError):

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -253,8 +253,12 @@ def _swiftclient_error_to_descriptive_exception(exc):
     if exc_headers and exc_headers.get('X-Trans-Id'):
         exc_str += ' X-Trans-Id: %s' % exc_headers['X-Trans-Id']
     if http_status == 403:
-        logger.error('unauthorized error in swift operation - %s', exc_str)
-        return UnauthorizedError(exc_str, exc)
+        # pass through of the InvalidObjectState error from S3 (but we only get exception message)
+        if "storage class" in exc_str:
+            raise stor_exceptions.ObjectInColdStorageError(exc_str, exc)
+        else:
+            logger.error('unauthorized error in swift operation - %s', exc_str)
+            return UnauthorizedError(exc_str, exc)
     elif http_status == 404:
         return NotFoundError(exc_str, exc)
     elif http_status == 409:

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -46,7 +46,7 @@ def _make_stat_response(stat_response=None):
     return [defaults]
 
 
-class TestPathcedGetAuthKeystone(unittest.TestCase):
+class TestPatchedGetAuthKeystone(unittest.TestCase):
     @mock.patch('stor.swift.real_get_auth_keystone', autospec=True)
     def test_patched_get_auth_keystone(self, mock_get_real_auth_keystone):
         mock_get_real_auth_keystone.side_effect = Exception
@@ -2715,3 +2715,15 @@ class TestIsMethods(SwiftTestCase):
         self.mock_swift.stat.side_effect = _service_404_exception()
         self.mock_list.side_effect = _service_404_exception()
         self.assertFalse(SwiftPath('swift://A/B/C').isdir())
+
+
+class TestExceptionParsing(unittest.TestCase):
+    def test_parse_cold_storage_error(self):
+        exc = ClientException(
+            http_reason='Forbidden', http_port=None, http_scheme='https', http_response_headers={},
+            http_response_content="The operation is not valid for the object's storage class",
+            http_device='', http_query='',
+            http_path='/v1/AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv',
+            http_host='swift.counsyl.com', http_status=403, msg='Object GET failed')
+        with self.assertRaises(exceptions.ObjectInColdStorageError):
+            swift._swiftclient_error_to_descriptive_exception(exc)


### PR DESCRIPTION
Previously would raise UnauthorizedError, now we raise
ObjectInColdStorageError.  This is backwards-incompatible because
previously it does not subclass UnauthorizedError. (but this is a good
thing because we no longer auto-retry when something is in cold storage)

```
›› stor cat swift://AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv
ObjectInColdStorageError: Object GET failed: https://swift.counsyl.com/v1/AUTH_seq_upload_prod/X5WGWBCXY_161212_D00254_1027_A/.data_manifest.csv 403 Forbidden   The operation is not valid for the object's storage class X-Trans-Id: txe76bdb09dd8f44bf8750e-005a66619e
```

Sem-Ver: api-break

cc @pkaleta @wesleykendall @krhaas

Closes #38 