### PR TITLE
Add `to_url()` method on Path and `url` cli

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,20 +1,17 @@
 Release Notes
 =============
 
-v1.5.4
+v1.6.0
 ------
 
+* Add ``to_url()`` method on Path and ``url`` cli method to translate swift and s3 paths to HTTP paths.
 * Add ``stor.makedirs_p(path, mode=0o777)`` to cross-compatible API. This does
   nothing on OBS-paths (just there for convenience).
-
-v1.5.3
-------
-
-* Hoist ``stor.utils.is_obs_path`` --> ``stor.is_obs_path``
 
 v1.5.2
 ------
 
+* Hoist ``stor.utils.is_obs_path`` --> ``stor.is_obs_path``
 * Build universal wheels for both Python 2 and Python 3.
   (no actual code changes)
 

--- a/stor/base.py
+++ b/stor/base.py
@@ -14,6 +14,7 @@ from six import string_types
 from six import PY3
 
 from stor import utils
+import six
 
 
 class TreeWalkWarning(Warning):

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -92,7 +92,7 @@ from stor import settings
 from stor import Path
 from stor import utils
 
-PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url')
+PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'uri')
 SERVICES = ('s3', 'swift')
 
 ENV_FILE = os.path.expanduser('~/.stor-cli.env')
@@ -268,10 +268,10 @@ def get_path(pth, mode=None):
     return prefix / path_part.split(rel_part, depth)[depth].lstrip('/')
 
 
-def _to_url(path):
+def _as_uri(path):
     if stor.is_filesystem_path(path):
         raise ValueError('must be swift or s3 path')
-    return stor.Path(path).to_url()
+    return stor.Path(path).as_uri()
 
 
 def create_parser():
@@ -376,9 +376,9 @@ def create_parser():
                                          ' will be cleared if SERVICE is omitted.' % clear_msg)
     parser_clear.add_argument('service', nargs='?', type=str, metavar='SERVICE')
     parser_clear.set_defaults(func=_clear_env)
-    url_parser = subparsers.add_parser('url', help='generate URL for swift or s3 path')
+    url_parser = subparsers.add_parser('uri', help='generate URI for path')
     url_parser.add_argument('path')
-    url_parser.set_defaults(func=_to_url)
+    url_parser.set_defaults(func=_as_uri)
 
     return parser
 

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -92,7 +92,7 @@ from stor import settings
 from stor import Path
 from stor import utils
 
-PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'uri')
+PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url')
 SERVICES = ('s3', 'swift')
 
 ENV_FILE = os.path.expanduser('~/.stor-cli.env')
@@ -268,10 +268,10 @@ def get_path(pth, mode=None):
     return prefix / path_part.split(rel_part, depth)[depth].lstrip('/')
 
 
-def _as_uri(path):
+def _to_url(path):
     if stor.is_filesystem_path(path):
         raise ValueError('must be swift or s3 path')
-    return stor.Path(path).as_uri()
+    return stor.Path(path).to_url()
 
 
 def create_parser():
@@ -376,9 +376,9 @@ def create_parser():
                                          ' will be cleared if SERVICE is omitted.' % clear_msg)
     parser_clear.add_argument('service', nargs='?', type=str, metavar='SERVICE')
     parser_clear.set_defaults(func=_clear_env)
-    url_parser = subparsers.add_parser('uri', help='generate URI for path')
+    url_parser = subparsers.add_parser('url', help='generate URI for path')
     url_parser.add_argument('path')
-    url_parser.set_defaults(func=_as_uri)
+    url_parser.set_defaults(func=_to_url)
 
     return parser
 

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -92,7 +92,7 @@ from stor import settings
 from stor import Path
 from stor import utils
 
-PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles')
+PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url')
 SERVICES = ('s3', 'swift')
 
 ENV_FILE = os.path.expanduser('~/.stor-cli.env')
@@ -268,6 +268,12 @@ def get_path(pth, mode=None):
     return prefix / path_part.split(rel_part, depth)[depth].lstrip('/')
 
 
+def _to_url(path):
+    if stor.is_filesystem_path(path):
+        raise ValueError('must be swift or s3 path')
+    return stor.Path(path).to_url()
+
+
 def create_parser():
     parser = argparse.ArgumentParser(description='A command line interface for stor.')
 
@@ -370,6 +376,9 @@ def create_parser():
                                          ' will be cleared if SERVICE is omitted.' % clear_msg)
     parser_clear.add_argument('service', nargs='?', type=str, metavar='SERVICE')
     parser_clear.set_defaults(func=_clear_env)
+    url_parser = subparsers.add_parser('url', help='generate URL for swift or s3 path')
+    url_parser.add_argument('path')
+    url_parser.set_defaults(func=_to_url)
 
     return parser
 

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -757,3 +757,8 @@ class S3Path(OBSPath):
 
         utils.check_condition(condition, [r['dest'] for r in uploaded['completed']])
         return uploaded
+
+    def to_url(self):
+        """Returns HTTPS path for object (virtual host-style)"""
+        return u'https://{bucket}.s3.amazonaws.com/{key}'.format(bucket=self.bucket,
+                                                                 key=self.resource)

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -758,7 +758,7 @@ class S3Path(OBSPath):
         utils.check_condition(condition, [r['dest'] for r in uploaded['completed']])
         return uploaded
 
-    def to_url(self):
-        """Returns HTTPS path for object (virtual host-style)"""
+    def as_uri(self):
+        """Returns HTTP uri for object (virtual host-style)"""
         return u'https://{bucket}.s3.amazonaws.com/{key}'.format(bucket=self.bucket,
                                                                  key=self.resource)

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -758,7 +758,7 @@ class S3Path(OBSPath):
         utils.check_condition(condition, [r['dest'] for r in uploaded['completed']])
         return uploaded
 
-    def as_uri(self):
-        """Returns HTTP uri for object (virtual host-style)"""
+    def to_url(self):
+        """Returns HTTP url for object (virtual host-style)"""
         return u'https://{bucket}.s3.amazonaws.com/{key}'.format(bucket=self.bucket,
                                                                  key=self.resource)

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -1564,11 +1564,11 @@ class SwiftPath(OBSPath):
                 if pattern is None or f.fnmatch(pattern):
                     yield f
 
-    def as_uri(self):
+    def to_url(self):
         """Returns URI for object (based on storage URL)
 
         Returns:
-            str: the HTTP uri to the object
+            str: the HTTP url to the object
         Raises:
             UnauthorizedError: if we cannot authenticate to get a storage URL"""
         storage_url = _get_or_create_auth_credentials(self.tenant)['os_storage_url']

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -1563,3 +1563,14 @@ class SwiftPath(OBSPath):
             for f in self.list(ignore_dir_markers=True):
                 if pattern is None or f.fnmatch(pattern):
                     yield f
+
+    def to_url(self):
+        """Returns path for object (based on storage URL)
+
+        Returns:
+            str: the http path
+        Raises:
+            UnauthorizedError: if we cannot authenticate to get a storage URL"""
+        storage_url = _get_or_create_auth_credentials(self.tenant)['os_storage_url']
+        return six.text_type(os.path.join(*filter(None,
+                                                  [storage_url, self.container, self.resource])))

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -1564,11 +1564,11 @@ class SwiftPath(OBSPath):
                 if pattern is None or f.fnmatch(pattern):
                     yield f
 
-    def to_url(self):
-        """Returns path for object (based on storage URL)
+    def as_uri(self):
+        """Returns URI for object (based on storage URL)
 
         Returns:
-            str: the http path
+            str: the HTTP uri to the object
         Raises:
             UnauthorizedError: if we cannot authenticate to get a storage URL"""
         storage_url = _get_or_create_auth_credentials(self.tenant)['os_storage_url']

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -459,6 +459,8 @@ class TestToUrl(BaseCliTest):
     def test_url(self):
         self.parse_args('stor url s3://test/file')
         self.assertEquals(sys.stdout.getvalue(), 'https://test.s3.amazonaws.com/file\n')
+        with self.assertRaisesRegexp(ValueError, 'must be swift or s3 path'):
+            self.parse_args('stor url /test/file')
 
 
 class TestCat(BaseCliTest):

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -455,6 +455,12 @@ class TestWalkfiles(BaseCliTest):
         mock_walkfiles.assert_called_once_with(PosixPath('.'))
 
 
+class TestToUrl(BaseCliTest):
+    def test_url(self):
+        self.parse_args('stor url s3://test/file')
+        self.assertEquals(sys.stdout.getvalue(), 'https://test.s3.amazonaws.com/file\n')
+
+
 class TestCat(BaseCliTest):
     @mock.patch.object(S3Path, 'read_object', autospec=True)
     def test_cat_s3(self, mock_read):

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -455,12 +455,17 @@ class TestWalkfiles(BaseCliTest):
         mock_walkfiles.assert_called_once_with(PosixPath('.'))
 
 
-class TestToUrl(BaseCliTest):
-    def test_url(self):
-        self.parse_args('stor url s3://test/file')
+class TestToUri(BaseCliTest):
+    def test_as_uri(self):
+        self.parse_args('stor uri s3://test/file')
         self.assertEquals(sys.stdout.getvalue(), 'https://test.s3.amazonaws.com/file\n')
-        with self.assertRaisesRegexp(ValueError, 'must be swift or s3 path'):
-            self.parse_args('stor url /test/file')
+
+    @mock.patch('sys.stderr', new=six.StringIO())
+    def test_file_uri_error(self):
+        with self.assertRaises(SystemExit):
+            self.parse_args('stor uri /test/file')
+        self.assertEquals(sys.stdout.getvalue(), '')
+        self.assertIn('must be swift or s3 path', sys.stderr.getvalue())
 
 
 class TestCat(BaseCliTest):

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -456,14 +456,14 @@ class TestWalkfiles(BaseCliTest):
 
 
 class TestToUri(BaseCliTest):
-    def test_as_uri(self):
-        self.parse_args('stor uri s3://test/file')
+    def test_to_url(self):
+        self.parse_args('stor url s3://test/file')
         self.assertEquals(sys.stdout.getvalue(), 'https://test.s3.amazonaws.com/file\n')
 
     @mock.patch('sys.stderr', new=six.StringIO())
     def test_file_uri_error(self):
         with self.assertRaises(SystemExit):
-            self.parse_args('stor uri /test/file')
+            self.parse_args('stor url /test/file')
         self.assertEquals(sys.stdout.getvalue(), '')
         self.assertIn('must be swift or s3 path', sys.stderr.getvalue())
 

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -50,9 +50,9 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('s3://bucket/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
-    def test_as_uri(self):
+    def test_to_url(self):
         p = Path('s3://mybucket/path/to/resource')
-        self.assertEquals(p.as_uri(),
+        self.assertEquals(p.to_url(),
                           'https://mybucket.s3.amazonaws.com/path/to/resource')
 
 

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -50,9 +50,9 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('s3://bucket/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
-    def test_to_url(self):
+    def test_as_uri(self):
         p = Path('s3://mybucket/path/to/resource')
-        self.assertEquals(p.to_url(),
+        self.assertEquals(p.as_uri(),
                           'https://mybucket.s3.amazonaws.com/path/to/resource')
 
 

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -50,6 +50,11 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('s3://bucket/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
+    def test_to_url(self):
+        p = Path('s3://mybucket/path/to/resource')
+        self.assertEquals(p.to_url(),
+                          'https://mybucket.s3.amazonaws.com/path/to/resource')
+
 
 class TestValidation(unittest.TestCase):
     def test_new_failed(self):

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -83,16 +83,16 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('swift://tenant/container/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
-    def test_as_uri(self):
+    def test_to_url(self):
         with mock.patch('stor.swift._get_or_create_auth_credentials',
                         # storage url may be an opaque value... ensure we roll with that
                         return_value={'os_storage_url': 'https://example.com/v1.0/othertenant',
                                       'os_auth_token': 'sometoken'}):
-            self.assertEquals(Path('swift://tenant/container/path/to/resource').as_uri(),
+            self.assertEquals(Path('swift://tenant/container/path/to/resource').to_url(),
                               'https://example.com/v1.0/othertenant/container/path/to/resource')
-            self.assertEquals(stor.Path('swift://tenant/container').as_uri(),
+            self.assertEquals(stor.Path('swift://tenant/container').to_url(),
                               'https://example.com/v1.0/othertenant/container')
-            self.assertEquals(stor.Path('swift://tenant').as_uri(),
+            self.assertEquals(stor.Path('swift://tenant').to_url(),
                               'https://example.com/v1.0/othertenant')
 
 

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -83,6 +83,18 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('swift://tenant/container/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
+    def test_to_url(self):
+        with mock.patch('stor.swift._get_or_create_auth_credentials',
+                        # storage url may be an opaque value... ensure we roll with that
+                        return_value={'os_storage_url': 'https://example.com/v1.0/othertenant',
+                                      'os_auth_token': 'sometoken'}):
+            self.assertEquals(Path('swift://tenant/container/path/to/resource').to_url(),
+                              'https://example.com/v1.0/othertenant/container/path/to/resource')
+            self.assertEquals(stor.Path('swift://tenant/container').to_url(),
+                              'https://example.com/v1.0/othertenant/container')
+            self.assertEquals(stor.Path('swift://tenant').to_url(),
+                              'https://example.com/v1.0/othertenant')
+
 
 class TestManifestUtilities(unittest.TestCase):
     def test_generate_save_and_read_manifest(self):

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -83,16 +83,16 @@ class TestBasicPathMethods(unittest.TestCase):
         p = Path('swift://tenant/container/path/to/resource')
         self.assertEquals(p.basename(), 'resource')
 
-    def test_to_url(self):
+    def test_as_uri(self):
         with mock.patch('stor.swift._get_or_create_auth_credentials',
                         # storage url may be an opaque value... ensure we roll with that
                         return_value={'os_storage_url': 'https://example.com/v1.0/othertenant',
                                       'os_auth_token': 'sometoken'}):
-            self.assertEquals(Path('swift://tenant/container/path/to/resource').to_url(),
+            self.assertEquals(Path('swift://tenant/container/path/to/resource').as_uri(),
                               'https://example.com/v1.0/othertenant/container/path/to/resource')
-            self.assertEquals(stor.Path('swift://tenant/container').to_url(),
+            self.assertEquals(stor.Path('swift://tenant/container').as_uri(),
                               'https://example.com/v1.0/othertenant/container')
-            self.assertEquals(stor.Path('swift://tenant').to_url(),
+            self.assertEquals(stor.Path('swift://tenant').as_uri(),
                               'https://example.com/v1.0/othertenant')
 
 


### PR DESCRIPTION
to translate swift and s3 paths to HTTP paths.

(also fix up release notes because versions got off when we were not
auto-releasing)

=> @kristjaneerik @kyleabeauchamp @pkaleta @krhaas