### PR TITLE
Do not generate buffers just to close them.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,17 +1,36 @@
 Release Notes
 =============
 
-v1.6.0
+v2.0.0
 ------
+
+API Additions
+^^^^^^^^^^^^^
+
 
 * Add ``to_url()`` method on Path and ``url`` cli method to translate swift and s3 paths to HTTP paths.
 * Add ``stor.makedirs_p(path, mode=0o777)`` to cross-compatible API. This does
   nothing on OBS-paths (just there for convenience).
+
+
+API Breaks
+^^^^^^^^^^
+
+* ``OBSFile`` can no longer (accidentally or intentionally) create zero-byte objects.
+
+
+Bug fixes
+^^^^^^^^^
+
+* ``OBSFile`` objects no longer attempt to load buffers on garbage collection.
+  This should resolve the ``Exception ignored in OBSFile.__del__`` messages and
+  eliminate "hangs" on garbage collection or closing python terminal.
+
+
+Other Changes
+^^^^^^^^^^^^^
+
 * ``stor`` no longer depends on ``cached-property``.
-* Fix bug with buffers that attempted to load buffers on close even if we'd
-  never actually loaded the underlying data. (and led to lots of ``Exception
-  ignored in OBSFile.__del__`` messages). This should reduce hangs on garbage
-  collection or closing python terminal.
 
 v1.5.2
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,11 @@ v1.6.0
 * Add ``to_url()`` method on Path and ``url`` cli method to translate swift and s3 paths to HTTP paths.
 * Add ``stor.makedirs_p(path, mode=0o777)`` to cross-compatible API. This does
   nothing on OBS-paths (just there for convenience).
+* ``stor`` no longer depends on ``cached-property``.
+* Fix bug with buffers that attempted to load buffers on close even if we'd
+  never actually loaded the underlying data. (and led to lots of ``Exception
+  ignored in OBSFile.__del__`` messages). This should reduce hangs on garbage
+  collection or closing python terminal.
 
 v1.5.2
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # have to explicitly ban certain requests versions to match keystoneauth1 package
 requests!=2.12.2,!=2.13.0,>=2.10.0
 boto3>=1.4.0
-cached_property
 python-keystoneclient>=1.8.1
 python-swiftclient
 six

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -117,14 +117,14 @@ class SharedOBSFileCases(object):
 
         self.assertTrue(obj.closed)
         self.assertFalse(mock_write_object.called)
-        self.assertFalse(obj._buffer_created)
+        self.assertFalse(obj._buffer)
 
     def test_invalid_buffer_mode(self):
         # internal error only
         fp = self.normal_path.open()
         fp.mode = 'invalid'
         with self.assertRaisesRegexp(ValueError, 'buffer'):
-            fp._buffer
+            fp._get_or_create_buffer()
 
     def test_invalid_open(self):
         pth = '{drive}B/C/D'.format(drive=self.drive)

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -130,17 +130,16 @@ class SharedOBSFileCases(object):
         pth = '{drive}B/C/D'.format(drive=self.drive)
         with self.assertRaisesRegexp(ValueError, 'mode'):
             # keep reference here
-            f = stor.open(pth, 'invalid')
-            assert False, 'should error before this'
-            f;
+            f = stor.open(pth, 'invalid')  # nopep8
+            assert False, 'should error before this'  # pragma: no cover
 
         with self.assertRaisesRegexp(ValueError, 'mode'):
             with stor.open(pth, 'invalid'):
-                assert False, 'should error before this'
+                assert False, 'should error before this'  # pragma: no cover
 
         with self.assertRaisesRegexp(ValueError, 'mode'):
             with stor.Path(pth).open('invalid'):
-                assert False, 'should error before this'
+                assert False, 'should error before this'  # pragma: no cover
 
     @mock_write_object
     @mock_read_object

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -79,6 +79,20 @@ class SharedOBSFileCases(object):
 
     @mock_write_object
     @mock_read_object
+    def test_empty_buffer_no_writes(self, mock_read_object, mock_write_object):
+        # NOTE: this tests that our current description (only non-empty buffers are uploaded) is
+        # enshrined.
+        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
+        fileobj.flush()
+        self.assertFalse(fileobj._buffer_created)
+        fileobj.write('')
+        fileobj.flush()
+        fileobj.close()
+        self.assertFalse(mock_read_object.called)
+        self.assertFalse(mock_write_object.called)
+
+    @mock_write_object
+    @mock_read_object
     def test_on_del_no_writes(self, mock_read_object, mock_write_object):
         fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
         del fileobj

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -48,14 +48,14 @@ class SharedOBSFileCases(object):
                               'file_data', 's_3_2126.bcl.gz')
         text = stor.open(gzip_path, 'rb').read()
         mock_read_object.return_value = text
-        fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+        fileobj = stor.open(stor.join(self.drive, 'A/C/s_3_2126.bcl.gz'), 'rb')
 
         with fileobj:
             with gzip.GzipFile(fileobj=fileobj) as fp:
                 with gzip.open(gzip_path) as gzip_fp:
                     assert_same_data(fp, gzip_fp)
 
-        fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+        fileobj = stor.open(stor.join(self.drive, 'A/C/s_3_2126.bcl.gz'), 'rb')
 
         with fileobj:
             with gzip.GzipFile(fileobj=fileobj) as fp:
@@ -85,7 +85,7 @@ class SharedOBSFileCases(object):
     def test_empty_buffer_no_writes(self, mock_read_object, mock_write_object):
         # NOTE: this tests that our current description (only non-empty buffers are uploaded) is
         # enshrined.
-        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
+        fileobj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
         fileobj.flush()
         self.assertFalse(fileobj._buffer)
         fileobj.write('')
@@ -97,14 +97,14 @@ class SharedOBSFileCases(object):
     @mock_write_object
     @mock_read_object
     def test_on_del_no_writes(self, mock_read_object, mock_write_object):
-        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
+        fileobj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
         del fileobj
         gc.collect()
 
         self.assertFalse(mock_read_object.called)
         self.assertFalse(mock_write_object.called)
 
-        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'r')
+        fileobj = stor.open(stor.join(self.drive, 'B/C/obj'), 'r')
         del fileobj
         gc.collect()
 
@@ -130,7 +130,7 @@ class SharedOBSFileCases(object):
             fp._get_or_create_buffer()
 
     def test_invalid_open(self):
-        pth = '{drive}B/C/D'.format(drive=self.drive)
+        pth = stor.join(self.drive, 'B/C/D')
         with self.assertRaisesRegexp(ValueError, 'mode'):
             # keep reference here
             f = stor.open(pth, 'invalid')  # nopep8

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -42,19 +42,22 @@ class SharedOBSFileCases(object):
     drive = None
     path_class = None
 
-    def test_works_with_gzip(self):
+    @mock_read_object
+    def test_works_with_gzip(self, mock_read_object):
         gzip_path = stor.join(stor.dirname(__file__),
                               'file_data', 's_3_2126.bcl.gz')
         text = stor.open(gzip_path, 'rb').read()
-        with mock.patch.object(self.path_class, 'read_object', autospec=True) as read_mock:
-            read_mock.return_value = text
-            fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+        mock_read_object.return_value = text
+        fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
 
+        with fileobj:
             with gzip.GzipFile(fileobj=fileobj) as fp:
                 with gzip.open(gzip_path) as gzip_fp:
                     assert_same_data(fp, gzip_fp)
 
-            fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+        fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+
+        with fileobj:
             with gzip.GzipFile(fileobj=fileobj) as fp:
                 with gzip.open(gzip_path) as gzip_fp:
                     # after seeking should still be same

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -120,10 +120,27 @@ class SharedOBSFileCases(object):
         self.assertFalse(obj._buffer_created)
 
     def test_invalid_buffer_mode(self):
+        # internal error only
         fp = self.normal_path.open()
         fp.mode = 'invalid'
         with self.assertRaisesRegexp(ValueError, 'buffer'):
             fp._buffer
+
+    def test_invalid_open(self):
+        pth = '{drive}B/C/D'.format(drive=self.drive)
+        with self.assertRaisesRegexp(ValueError, 'mode'):
+            # keep reference here
+            f = stor.open(pth, 'invalid')
+            assert False, 'should error before this'
+            f;
+
+        with self.assertRaisesRegexp(ValueError, 'mode'):
+            with stor.open(pth, 'invalid'):
+                assert False, 'should error before this'
+
+        with self.assertRaisesRegexp(ValueError, 'mode'):
+            with stor.Path(pth).open('invalid'):
+                assert False, 'should error before this'
 
     @mock_write_object
     @mock_read_object

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -1,0 +1,164 @@
+"""
+Shared unittests for Swift and S3
+=================================
+
+This file contains a number of shared tests that vary only based upon which concrete class
+(SwiftPath or S3Path) is tested.
+"""
+
+import functools
+import gc
+import gzip
+
+import mock
+import six
+
+from stor import obs
+from stor.tests.shared import assert_same_data
+
+import stor
+
+
+def mock_method_on_Path(method_name):
+    """Generates a decorator that will mock the appropriate method on the concrete path object
+    (either S3Path or SwiftPath)"""
+    def mocker(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            with mock.patch.object(self.path_class, method_name, autospec=True) as method_mock:
+                return f(self, method_mock, *args, **kwargs)
+        return wrapper
+    mocker.__name__ = 'mock_%s' % method_name
+    return mocker
+
+
+mock_write_object = mock_method_on_Path('write_object')
+mock_read_object = mock_method_on_Path('read_object')
+
+
+class SharedOBSFileCases(object):
+    """Tests that only rely on read_object() on underlying path class to be called, so we can just
+    parametrize on drive and path"""
+    drive = None
+    path_class = None
+
+    def test_works_with_gzip(self):
+        gzip_path = stor.join(stor.dirname(__file__),
+                              'file_data', 's_3_2126.bcl.gz')
+        text = stor.open(gzip_path, 'rb').read()
+        with mock.patch.object(self.path_class, 'read_object', autospec=True) as read_mock:
+            read_mock.return_value = text
+            fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+
+            with gzip.GzipFile(fileobj=fileobj) as fp:
+                with gzip.open(gzip_path) as gzip_fp:
+                    assert_same_data(fp, gzip_fp)
+
+            fileobj = stor.open('{drive}A/C/s_3_2126.bcl.gz'.format(drive=self.drive), 'rb')
+            with gzip.GzipFile(fileobj=fileobj) as fp:
+                with gzip.open(gzip_path) as gzip_fp:
+                    # after seeking should still be same
+                    fp.seek(3)
+                    gzip_fp.seek(3)
+                    assert_same_data(fp, gzip_fp)
+
+    def test_makedirs_p_does_nothing(self):
+        # dumb test... but why not?
+        self.normal_path.makedirs_p()
+
+    @mock_read_object
+    def test_context_manager_on_closed_file(self, mock_read_object):
+        mock_read_object.return_value = b'data'
+        pth = self.normal_path
+        obj = pth.open()
+        obj.close()
+
+        with self.assertRaisesRegexp(ValueError, 'closed file'):
+            with obj:
+                pass  # pragma: no cover
+
+    @mock_write_object
+    @mock_read_object
+    def test_on_del_no_writes(self, mock_read_object, mock_write_object):
+        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
+        del fileobj
+        gc.collect()
+
+        self.assertFalse(mock_read_object.called)
+        self.assertFalse(mock_write_object.called)
+
+        fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'r')
+        del fileobj
+        gc.collect()
+
+        self.assertFalse(mock_read_object.called)
+        self.assertFalse(mock_write_object.called)
+
+    @mock.patch('time.sleep', autospec=True)
+    @mock_write_object
+    def test_close_no_writes(self, mock_write_object, mock_sleep):
+        pth = self.normal_path
+        obj = pth.open(mode='wb')
+        obj.close()
+
+        self.assertTrue(obj.closed)
+        self.assertFalse(mock_write_object.called)
+        self.assertFalse(obj._buffer_created)
+
+    def test_invalid_buffer_mode(self):
+        fp = self.normal_path.open()
+        fp.mode = 'invalid'
+        with self.assertRaisesRegexp(ValueError, 'buffer'):
+            fp._buffer
+
+    @mock_write_object
+    @mock_read_object
+    def test_invalid_flush_mode(self, mock_read_object, mock_write_object):
+        mock_read_object.return_value = b'data'
+        obj = self.normal_path.open()
+        with self.assertRaisesRegexp(TypeError, 'flush'):
+            obj.flush()
+        self.assertFalse(mock_write_object.called)
+        # should not read it if we didn't ever use it
+        self.assertFalse(mock_read_object.called)
+
+    def test_name(self):
+        obj = self.normal_path.open()
+        self.assertEquals(obj.name, self.normal_path)
+
+    @mock_read_object
+    def test_read_on_closed_file(self, mock_read_object):
+        mock_read_object.return_value = b'data'
+        obj = self.normal_path.open()
+        obj.close()
+
+        with self.assertRaisesRegexp(ValueError, 'closed file'):
+            obj.read()
+
+    def test_invalid_io_op(self):
+        # now invalid delegates are considered invalid on instantiation
+        with self.assertRaisesRegexp(AttributeError, 'no attribute'):
+            class MyFile(object):
+                closed = False
+                _buffer = six.BytesIO()
+                invalid = obs._delegate_to_buffer('invalid')
+
+    def test_read_invalid_mode(self):
+        pth = self.normal_path
+        with self.assertRaisesRegexp(TypeError, 'mode.*read'):
+            pth.open(mode='wb').read()
+
+    def test_write_invalid_args(self):
+        pth = self.normal_path
+        obj = pth.open(mode='r')
+        with self.assertRaisesRegexp(TypeError, 'mode.*write'):
+            obj.write('hello')
+
+    @mock.patch('time.sleep', autospec=True)
+    @mock_write_object
+    def test_write_multiple_w_context_manager(self, mock_write_object, mock_sleep):
+        with self.normal_path.open(mode='wb') as obj:
+            obj.write(b'hello')
+            obj.write(b' world')
+        mock_write_object.assert_called_with(self.normal_path, b'hello world')
+        self.assertEquals(len(mock_write_object.call_args_list), 1)

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -84,7 +84,7 @@ class SharedOBSFileCases(object):
         # enshrined.
         fileobj = stor.open('{drive}B/C/obj'.format(drive=self.drive), 'w')
         fileobj.flush()
-        self.assertFalse(fileobj._buffer_created)
+        self.assertFalse(fileobj._buffer)
         fileobj.write('')
         fileobj.flush()
         fileobj.close()
@@ -191,4 +191,16 @@ class SharedOBSFileCases(object):
             obj.write(b'hello')
             obj.write(b' world')
         mock_write_object.assert_called_with(self.normal_path, b'hello world')
+        self.assertEquals(len(mock_write_object.call_args_list), 1)
+
+    @mock_write_object
+    def test_seek_behavior_and_writes(self, mock_write_object):
+        with self.normal_path.open(mode='wb') as obj:
+            obj.write(b'happy go lucky')
+            obj.seek(5)
+            obj.write(b'-')
+            obj.seek(8)
+            obj.write(b'_')
+            obj.seek(0)
+        mock_write_object.assert_called_with(self.normal_path, b'happy-go_lucky')
         self.assertEquals(len(mock_write_object.call_args_list), 1)

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -1,4 +1,3 @@
-import gzip
 import logging
 import ntpath
 import os
@@ -7,7 +6,6 @@ import unittest
 
 import freezegun
 import mock
-import six
 from swiftclient.exceptions import ClientException
 from swiftclient.service import SwiftError
 from testfixtures import LogCapture
@@ -21,7 +19,7 @@ from stor import swift
 from stor import utils
 from stor.swift import SwiftPath
 from stor.test import SwiftTestCase
-from stor.tests.shared import assert_same_data
+from stor.tests.shared_obs import SharedOBSFileCases
 
 
 def _service_404_exception():
@@ -243,51 +241,6 @@ class TestSwiftFile(SwiftTestCase):
         super(TestSwiftFile, self).setUp()
         settings.update({'swift': {'num_retries': 5}})
 
-    def test_makedirs_p_does_nothing(self):
-        # dumb test... but why not?
-        SwiftPath('swift://tenant/container/obj').makedirs_p()
-
-    def test_invalid_buffer_mode(self):
-        swift_f = SwiftPath('swift://tenant/container/obj').open()
-        swift_f.mode = 'invalid'
-        with self.assertRaisesRegexp(ValueError, 'buffer'):
-            swift_f._buffer
-
-    def test_invalid_flush_mode(self):
-        self.mock_swift_conn.get_object.return_value = ('header', b'data')
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        obj = swift_p.open()
-        with self.assertRaisesRegexp(TypeError, 'flush'):
-            obj.flush()
-
-    def test_name(self):
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        obj = swift_p.open()
-        self.assertEquals(obj.name, swift_p)
-
-    def test_context_manager_on_closed_file(self):
-        self.mock_swift_conn.get_object.return_value = ('header', b'data')
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        obj = swift_p.open()
-        obj.close()
-
-        with self.assertRaisesRegexp(ValueError, 'closed file'):
-            with obj:
-                pass  # pragma: no cover
-
-    def test_invalid_mode(self):
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        with self.assertRaisesRegexp(ValueError, 'invalid mode'):
-            swift_p.open(mode='invalid')
-
-    def test_invalid_io_op(self):
-        # now invalid delegates are considered invalid on instantiation
-        with self.assertRaisesRegexp(AttributeError, 'no attribute'):
-            class MyFile(object):
-                closed = False
-                _buffer = six.BytesIO()
-                invalid = swift._delegate_to_buffer('invalid')
-
     def test_read_on_closed_file(self):
         self.mock_swift_conn.get_object.return_value = ('header', b'data')
         swift_p = SwiftPath('swift://tenant/container/obj')
@@ -297,15 +250,11 @@ class TestSwiftFile(SwiftTestCase):
         with self.assertRaisesRegexp(ValueError, 'closed file'):
             obj.read()
 
-    def test_read_invalid_mode(self):
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        with self.assertRaisesRegexp(TypeError, 'mode.*read'):
-            swift_p.open(mode='wb').read()
-
     def test_read_success(self):
         self.mock_swift_conn.get_object.return_value = ('header', b'data')
 
         swift_p = SwiftPath('swift://tenant/container/obj')
+        self.assertEquals(swift_p.read_object(), b'data')
         self.assertEquals(swift_p.open().read(), 'data')
 
     def test_iterating_over_files(self):
@@ -340,12 +289,6 @@ line4
         obj = swift_p.open()
         self.assertEquals(obj.read(), 'data')
         self.assertEquals(len(mock_sleep.call_args_list), 1)
-
-    def test_write_invalid_args(self):
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        obj = swift_p.open(mode='r')
-        with self.assertRaisesRegexp(TypeError, 'mode.*write'):
-            obj.write('hello')
 
     @mock.patch('time.sleep', autospec=True)
     @mock.patch.object(SwiftPath, 'upload', autospec=True)
@@ -404,33 +347,11 @@ line4
                 # additional file change
                 self.assertEqual(open(ntf3.name).read(), 'hello world')
 
-    @mock.patch('time.sleep', autospec=True)
-    @mock.patch.object(SwiftPath, 'upload', autospec=True)
-    def test_close_no_writes(self, mock_upload, mock_sleep):
-        swift_p = SwiftPath('swift://tenant/container/obj')
-        obj = swift_p.open(mode='wb')
-        obj.close()
 
-        self.assertFalse(mock_upload.called)
-
-    def test_works_with_gzip(self):
-        gzip_path = stor.join(stor.dirname(__file__),
-                              'file_data', 's_3_2126.bcl.gz')
-        text = stor.open(gzip_path, 'rb').read()
-        with mock.patch.object(SwiftPath, 'read_object', autospec=True) as read_mock:
-            read_mock.return_value = text
-            swift_file = stor.open('swift://A/C/s_3_2126.bcl.gz', 'rb')
-
-            with gzip.GzipFile(fileobj=swift_file) as swift_file_fp:
-                with gzip.open(gzip_path) as gzip_fp:
-                    assert_same_data(swift_file_fp, gzip_fp)
-            swift_file = stor.open('swift://A/C/s_3_2126.bcl.gz', 'rb')
-            with gzip.GzipFile(fileobj=swift_file) as swift_file_fp:
-                with gzip.open(gzip_path) as gzip_fp:
-                    # after seeking should still be same
-                    swift_file_fp.seek(3)
-                    gzip_fp.seek(3)
-                    assert_same_data(swift_file_fp, gzip_fp)
+class TestSwiftShared(SharedOBSFileCases, SwiftTestCase):
+    drive = 'swift://'
+    path_class = SwiftPath
+    normal_path = SwiftPath('swift://tenant/container/obj')
 
 
 class TestTempURL(SwiftTestCase):


### PR DESCRIPTION
Previously we were creating buffers in the ``close()`` method in order
to call ``close()`` on them and/or causing uploads in the close method
in an attempt to upload an empty file. For strict compatibility with
POSIX, we probably should create an empty file if we open but do
not close an object, but this means we can potentially generate an error
in a close method in an edge case that isn't that fun.

This is not an API-breaking change, because previously we checked for
buffer.tell() in flush, so no empty files are created.

Closes #50.