### PR TITLE
Remove deprecated top-level methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ with a single, cross-compatible API.
 ## Quickstart - CLI
 
 ```
-usage: stor [-h] [-c CONFIG_FILE] [--version]  ...
+usage: stor [-h] [-c CONFIG_FILE] [--version]
+            {list,ls,cp,rm,walkfiles,cat,cd,pwd,clear,url,convert-swiftstack}
+            ...
 
 A command line interface for stor.
 
 positional arguments:
-
+  {list,ls,cp,rm,walkfiles,cat,cd,pwd,clear,url,convert-swiftstack}
     list                List contents using the path as a prefix.
     ls                  List path as a directory.
-    cp                  Alias for copy.
+    cp                  Copy a source to a destination path.
     rm                  Remove file at a path.
     walkfiles           List all files under a path that match an optional
                         pattern.
@@ -44,6 +46,14 @@ positional arguments:
     pwd                 Get the present working directory of a service or all
                         current directories.
     clear               Clear current directories of a specified service.
+    url                 generate URI for path
+    convert-swiftstack  convert swiftstack paths
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG_FILE, --config CONFIG_FILE
+                        File containing configuration settings.
+  --version             Print version
 ```
 
 You can `ls` local and remote directories

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -25,6 +25,7 @@ API Breaks
 
 * ``OBSFile`` can no longer (accidentally or intentionally) create zero-byte objects.
 * GETs on unrestored Glacier objects no longer raise ``UnauthorizedError`` (see above).
+* Removed already-deprecated ``stor.listpath`` and ``stor.path``.
 
 
 Bug fixes

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -34,6 +34,7 @@ Bug fixes
 * ``OBSFile`` objects no longer attempt to load buffers on garbage collection.
   This should resolve the ``Exception ignored in OBSFile.__del__`` messages and
   eliminate "hangs" on garbage collection or closing python terminal.
+* ``stor cp`` no longer claims to be an alias of copy.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -90,27 +90,6 @@ def glob(pth, pattern):  # pragma: no cover
     return Path(pth).glob(pattern)
 
 
-def listpath(pth):  # pragma: no cover
-    import warnings
-
-    # DeprecationWarnings are hidden by default. We want to get rid of this
-    # sooner rather than later.
-    warnings.warn('Using the ``stor.listpath()`` function directly is'
-                  ' deprecated, use ``stor.list()`` instead', UserWarning)
-    return list(pth)
-
-
-def path(pth):  # pragma: no cover
-    import warnings
-
-    # DeprecationWarnings are hidden by default. We want to get rid of this
-    # sooner rather than later.
-    warnings.warn('Using the ``path()`` function directly is deprecated -'
-                  ' either use stor.Path or the functional API'
-                  ' directly', UserWarning)
-    return Path(pth)
-
-
 __all__ = [
     'abspath',
     'normcase',

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -327,7 +327,6 @@ def create_parser():
     parser_ls.set_defaults(func=stor.listdir)
 
     cp_msg = 'Copy a source to a destination path.'
-    cp_msg = 'Alias for copy.'
     parser_cp = subparsers.add_parser('cp',  # noqa
                                       help=cp_msg,
                                       description='%s\n \'-\' is a special character that allows'

--- a/stor/tests/test_posix.py
+++ b/stor/tests/test_posix.py
@@ -255,13 +255,6 @@ class TestList(unittest.TestCase):
                                                './dir/dir2/file4.txt']))
 
 
-class TestListpath(unittest.TestCase):
-    @mock.patch('stor.list', autospec=True)
-    def test_deprecated_listpath(self, mock_list):
-        stor.listpath('.')
-        mock_list.assert_called_once_with('.')
-
-
 class TestWalkfiles(unittest.TestCase):
     def test_walkfiles(self):
         with NamedTemporaryDirectory(change_dir=True):


### PR DESCRIPTION
1. remove `stor.listpath` and `stor.path`, both of which have been deprecated for a long time (and we're releasing v2.0 very soon anyways!)
2. update README.md to reflect new CLI options
3. change stor cp to no longer say "Alias for copy"

@kyleabeauchamp @pkaleta cc @wesleykendall 