### PR TITLE
Make s3 test bucket configurable + append UUID to bucket name

### DIFF
--- a/stor/tests/test_integration_s3.py
+++ b/stor/tests/test_integration_s3.py
@@ -37,7 +37,8 @@ class S3IntegrationTest(BaseIntegrationTest.BaseTestCases):
         # Disable loggers so nose output is clean
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
         test_bucket = os.environ['S3_TEST_BUCKET']
-        self.test_bucket = Path('s3://{test_bucket}/{uuid}'.format(test_bucket=test_bucket, uuid=uuid.uuid4()))
+        self.test_bucket = Path('s3://{test_bucket}/{uuid}'.format(test_bucket=test_bucket,
+                                                                   uuid=uuid.uuid4()))
         self.test_dir = self.test_bucket / 'test'
         stor.settings.update({
             's3': {

--- a/stor/tests/test_integration_s3.py
+++ b/stor/tests/test_integration_s3.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 import unittest
+import uuid
 
 import six
 
@@ -27,15 +28,16 @@ class S3IntegrationTest(BaseIntegrationTest.BaseTestCases):
         super(S3IntegrationTest, self).setUp()
 
         if not (os.environ.get('AWS_TEST_ACCESS_KEY_ID') and
-                os.environ.get('AWS_TEST_SECRET_ACCESS_KEY')):
+                os.environ.get('AWS_TEST_SECRET_ACCESS_KEY') and
+                os.environ.get('S3_TEST_BUCKET')):
             raise unittest.SkipTest(
-                'AWS_TEST_ACCESS_KEY_ID / AWS_TEST_SECRET_ACCESS_KEY env var not set.'
-                ' Skipping integration test')
+                'AWS_TEST_ACCESS_KEY_ID / AWS_TEST_SECRET_ACCESS_KEY / S3_TEST_BUCKET '
+                ' env vars not set. Skipping integration test')
 
         # Disable loggers so nose output is clean
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
-
-        self.test_bucket = Path('s3://stor-test-bucket')
+        test_bucket = os.environ['S3_TEST_BUCKET']
+        self.test_bucket = Path('s3://{test_bucket}/{uuid}'.format(test_bucket=test_bucket, uuid=uuid.uuid4()))
         self.test_dir = self.test_bucket / 'test'
         stor.settings.update({
             's3': {


### PR DESCRIPTION
Makes it possible to run s3 integration tests against your own S3 bucket + ensures that multiple test runs do not clobber each other. (previously they'd all run at $BUCKET/test, which is kinda silly)

@kyleabeauchamp @pkaleta 