### PR TITLE
Add S3Path.restore to restore objects from Glacier to S3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v2.1.0
+------
+
+* Add ``stor.S3Path.restore(days, tier)`` to restore objects from Glacier to S3.
+  Paired with this change are two specific exceptions related to S3 restores,
+  ``RestoreAlreadyInProgressError`` (raised when restore has already started)
+  and ``AlreadyRestoredError`` (raised when restoring object already in S3).
+* Move ``ConflictError`` to ``stor.exceptions`` (still available under ``stor.swift``)
+
 v2.0.0
 ------
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 v2.1.0
 ------
 
-* Add ``stor.S3Path.restore(days, tier)`` to restore objects from Glacier to S3.
+* Add ``stor.S3Path.restore(days, tier)`` to restore *single* objects from Glacier to S3.
   Paired with this change are two specific exceptions related to S3 restores,
   ``RestoreAlreadyInProgressError`` (raised when restore has already started)
   and ``AlreadyRestoredError`` (raised when restoring object already in S3).

--- a/stor/exceptions.py
+++ b/stor/exceptions.py
@@ -34,7 +34,7 @@ class NotFoundError(RemoteError):
 
 
 class InvalidObjectStateError(RemoteError):
-    """Base class for 403 errors from S3/SwiftStack dealing with"""
+    """Base class for 403 errors from S3 dealing with storage classes."""
 
 
 class ObjectInColdStorageError(InvalidObjectStateError):

--- a/stor/exceptions.py
+++ b/stor/exceptions.py
@@ -33,7 +33,11 @@ class NotFoundError(RemoteError):
     pass
 
 
-class ObjectInColdStorageError(RemoteError):
+class InvalidObjectStateError(RemoteError):
+    """Base class for 403 errors from S3/SwiftStack dealing with"""
+
+
+class ObjectInColdStorageError(InvalidObjectStateError):
     """Thrown when a 403 is returned from S3/SwiftStack because backing data is on Glacier.
 
     Note:
@@ -43,6 +47,10 @@ class ObjectInColdStorageError(RemoteError):
 
     .. _S3 Rest API GET: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
     """
+
+
+class AlreadyRestoredError(InvalidObjectStateError):
+    """Thrown on attempt to restore object already not in Glacier"""
 
 
 class UnauthorizedError(RemoteError):
@@ -61,6 +69,22 @@ class UnauthorizedError(RemoteError):
 class UnavailableError(RemoteError):
     """Thrown when a 503 response is returned."""
     pass
+
+
+class ConflictError(RemoteError):
+    """Thrown when a 409 response is returned.
+
+    Notes:
+        * **Swift**: This error is thrown when deleting a container and
+          some object storage nodes report that the container
+          has objects while others don't.
+        * **S3**: Raised when attempting to restore object that's already being restored (as
+          RestoreAlreadyInProgressError). Possibly in other cases.
+    """
+
+
+class RestoreAlreadyInProgressError(ConflictError):
+    """Thrown when RestoreAlreadyInProgress on glacier restore"""
 
 
 class ConditionNotMetError(RemoteError):

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -771,13 +771,16 @@ class S3Path(OBSPath):
                                                                  key=self.resource)
 
     def restore(self, tier='Bulk', days=10):
-        """Issue a restore command for the object from glacier.
+        """Issue a restore command for a single object from glacier.
 
         Args:
             tier (str, optional): restore speed (see Glacier docs for details)
             days (int, optional): number of days to keep data in S3 post-restore.
         Returns:
             dict or None: restore response from S3 client
+        Note:
+            Calling ``restore()`` on a directory will not work correctly. Only use this for single
+            objects! (you can always do ``[s.restore() for s in stor.list(<directory>)]``)
 
         Ignores RestoreAlreadyInProgressError and AlreadyRestoredError (note that you can't force
         S3 to do a faster restore once you've chosen a tier)

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -774,10 +774,8 @@ class S3Path(OBSPath):
         """Issue a restore command for a single object from glacier.
 
         Args:
-            tier (str, optional): restore speed (see Glacier docs for details)
-            days (int, optional): number of days to keep data in S3 post-restore.
-        Returns:
-            dict or None: restore response from S3 client
+            tier (str, default 'Bulk'): restore speed (see Glacier docs for details)
+            days (int, default 10): number of days to keep data in S3 post-restore.
         Note:
             Calling ``restore()`` on a directory will not work correctly. Only use this for single
             objects! (you can always do ``[s.restore() for s in stor.list(<directory>)]``)
@@ -787,7 +785,7 @@ class S3Path(OBSPath):
         """
         valid_tiers = ('Standard', 'Bulk', 'Expedited')
         if tier not in valid_tiers:
-            raise TypeError('`tier` must be one of {}'.format(valid_tiers))
+            raise ValueError('`tier` must be one of {}'.format(valid_tiers))
         try:
             self._s3_client_call('restore_object',
                                  Bucket=self.bucket,
@@ -796,7 +794,5 @@ class S3Path(OBSPath):
                                                  'GlacierJobParameters': {'Tier': tier}})
         except exceptions.RestoreAlreadyInProgressError:
             logger.debug('restore already started, not doing anything')
-            return None
         except exceptions.AlreadyRestoredError:
             logger.debug('already restored, not doing anything')
-            return None

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -49,19 +49,21 @@ def _parse_s3_error(exc, **kwargs):
         if 'storage class' in msg and code == 'InvalidObjectState':
             if operation_name == 'GetObject':
                 return exceptions.ObjectInColdStorageError(msg, exc)
-            if operation_name == 'RestoreObject':
+            elif operation_name == 'RestoreObject':
                 return exceptions.AlreadyRestoredError(msg, exc)
-        return exceptions.UnauthorizedError(msg, exc)
-    if http_status == 404:
+            else:
+                return exceptions.UnauthorizedError(msg, exc)
+    elif http_status == 404:
         return exceptions.NotFoundError(msg, exc)
-    if http_status == 503:
+    elif http_status == 503:
         return exceptions.UnavailableError(msg, exc)
-    if http_status == 409:
+    elif http_status == 409:
         if 'Object restore is already in progress' in msg:
             return exceptions.RestoreAlreadyInProgressError(msg, exc)
-        return exceptions.ConflictError(msg, exc)
-
-    return exceptions.RemoteError(msg, exc)
+        else:  # pragma: no cover
+            return exceptions.ConflictError(msg, exc)
+    else:
+        return exceptions.RemoteError(msg, exc)
 
 
 def _get_s3_client():

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -51,8 +51,9 @@ def _parse_s3_error(exc, **kwargs):
                 return exceptions.ObjectInColdStorageError(msg, exc)
             elif operation_name == 'RestoreObject':
                 return exceptions.AlreadyRestoredError(msg, exc)
-            else:
-                return exceptions.UnauthorizedError(msg, exc)
+            else:  # pragma: no cover
+                pass
+        return exceptions.UnauthorizedError(msg, exc)
     elif http_status == 404:
         return exceptions.NotFoundError(msg, exc)
     elif http_status == 503:

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -52,8 +52,9 @@ def _parse_s3_error(exc, **kwargs):
             elif operation_name == 'RestoreObject':
                 return exceptions.AlreadyRestoredError(msg, exc)
             else:  # pragma: no cover
-                pass
-        return exceptions.UnauthorizedError(msg, exc)
+                return exceptions.UnauthorizedError(msg, exc)
+        else:
+            return exceptions.UnauthorizedError(msg, exc)
     elif http_status == 404:
         return exceptions.NotFoundError(msg, exc)
     elif http_status == 503:

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -99,6 +99,7 @@ initial_retry_sleep = 1
 SwiftError = stor_exceptions.RemoteError
 NotFoundError = stor_exceptions.NotFoundError
 ConditionNotMetError = stor_exceptions.ConditionNotMetError
+ConflictError = stor_exceptions.ConflictError
 UnavailableError = stor_exceptions.UnavailableError
 UnauthorizedError = stor_exceptions.UnauthorizedError
 SwiftFile = OBSFile
@@ -185,16 +186,6 @@ class AuthenticationError(SwiftError):
 
     Swiftclient throws this error when trying to authenticate with
     the keystone client. This is similar to a 401 HTTP response.
-    """
-    pass
-
-
-class ConflictError(SwiftError):
-    """Thrown when a 409 response is returned from swift
-
-    This error is thrown when deleting a container and
-    some object storage nodes report that the container
-    has objects while others don't.
     """
     pass
 

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1412,7 +1412,7 @@ class TestRestore(S3TestCase):
         self.mock_get_s3_client.return_value.restore_object.assert_called_with(
             Bucket='bucket', Key='key/obj', RestoreRequest={'Days': 29, 'GlacierJobParameters':
                                                             {'Tier': 'Expedited'}})
-        with self.assertRaisesRegexp(TypeError, 'tier.*Standard'):
+        with self.assertRaisesRegexp(ValueError, 'tier.*Standard'):
             s3_p.restore(tier='Blah')
 
     def test_restore_with_exception(self):

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1405,6 +1405,29 @@ class TestCopytree(S3TestCase):
         self.assertEquals(s3_p.read_object(), b'data')
 
 
+class TestRestore(S3TestCase):
+    def test_restore_normal(self):
+        s3_p = S3Path('s3://bucket/key/obj')
+        s3_p.restore(days=29, tier='Expedited')
+        self.mock_get_s3_client.return_value.restore_object.assert_called_with(
+            Bucket='bucket', Key='key/obj', RestoreRequest={'Days': 29, 'GlacierJobParameters':
+                                                            {'Tier': 'Expedited'}})
+        with self.assertRaisesRegexp(TypeError, 'tier.*Standard'):
+            s3_p.restore(tier='Blah')
+
+    def test_restore_with_exception(self):
+        self.mock_get_s3_client.return_value.restore_object.side_effect =\
+            exceptions.ConflictError('blah')
+        with self.assertRaises(exceptions.ConflictError):
+            S3Path('s3://bucket/key/obj').restore()
+
+    def test_restore_with_known_exception(self):
+        self.mock_get_s3_client.return_value.restore_object.side_effect =\
+            exceptions.RestoreAlreadyInProgressError('blah')
+        S3Path('s3://bucket/key/obj').restore()
+        assert self.mock_get_s3_client.return_value.restore_object.called
+
+
 class TestS3File(S3TestCase):
     @mock.patch('botocore.response.StreamingBody', autospec=True)
     def test_read_success(self, mock_stream):
@@ -1519,7 +1542,7 @@ class TestSessionSettings(unittest.TestCase):
 class TestS3ErrorParsing(unittest.TestCase):
     def test_cold_storage_exception(self):
         exc = ClientError(
-            error_response={
+            {
                 'ResponseMetadata': {
                     'HTTPStatusCode': 403, 'RetryAttempts': 0, 'HostId': '',
                     'RequestId': '53AA120E409A4EB7',
@@ -1530,12 +1553,52 @@ class TestS3ErrorParsing(unittest.TestCase):
                                     'content-type': 'application/xml'}
                 },
                 'Error': {
-                        'Message': "The operation is not valid for the object's storage class",
-                        'Code': 'InvalidObjectState'
+                    'Message': "The operation is not valid for the object's storage class",
+                    'Code': 'InvalidObjectState'
                 }
             },
-            operation_name=u'GetObject')
+            u'GetObject')
         obj = s3._parse_s3_error(exc, Bucket='BUCKETNAME', Key='KEYNAME')
         self.assertIsInstance(obj, exceptions.ObjectInColdStorageError)
         self.assertIn('Bucket: BUCKETNAME', str(obj))
         self.assertIn('Key: KEYNAME', str(obj))
+
+    def test_already_restoring_error(self):
+        error_response = {
+            'Error': {'Code': 'RestoreAlreadyInProgress',
+                      'Message': 'Object restore is already in progress'},
+            'ResponseMetadata': {'HTTPHeaders': {'content-type': 'application/xml',
+                                                 'date': 'Mon, 05 Mar 2018 19:26:11 GMT',
+                                                 'server': 'AmazonS3',
+                                                 'transfer-encoding': 'chunked',
+                                                 'x-amz-id-2': '',
+                                                 'x-amz-request-id': 'FC1D76375EF41CED'},
+                                 'HTTPStatusCode': 409,
+                                 'HostId': '',
+                                 'RequestId': 'FC1D76375EF41CED',
+                                 'RetryAttempts': 0}}
+        obj = s3._parse_s3_error(ClientError(error_response, u'RestoreObject'),
+                                 Bucket='BUCKETNAME', Key='KEYNAME')
+        self.assertIsInstance(obj, exceptions.RestoreAlreadyInProgressError)
+
+    def test_already_restored_exception(self):
+        error_response = {
+            'Error': {
+                'Code': 'InvalidObjectState',
+                'Message': "Restore is not allowed, as object's storage class is not GLACIER"
+            },
+            'ResponseMetadata': {'HTTPHeaders': {'connection': 'close',
+                                                 'content-type': 'application/xml',
+                                                 'date': 'Mon, 05 Mar 2018 18:53:56 GMT',
+                                                 'server': 'AmazonS3',
+                                                 'transfer-encoding': 'chunked',
+                                                 'x-amz-id-2': 'txt',
+                                                 'x-amz-request-id': '29C9FD65B889D4A6'},
+                                 'HTTPStatusCode': 403,
+                                 'HostId': '',
+                                 'RequestId': '29C9FD65B889D4A6',
+                                 'RetryAttempts': 0}
+        }
+        obj = s3._parse_s3_error(ClientError(error_response, u'RestoreObject'),
+                                 Bucket='BUCKETNAME', Key='KEYNAME')
+        self.assertIsInstance(obj, exceptions.AlreadyRestoredError)

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1422,10 +1422,13 @@ class TestRestore(S3TestCase):
             S3Path('s3://bucket/key/obj').restore()
 
     def test_restore_with_known_exception(self):
-        self.mock_get_s3_client.return_value.restore_object.side_effect =\
-            exceptions.RestoreAlreadyInProgressError('blah')
-        S3Path('s3://bucket/key/obj').restore()
-        assert self.mock_get_s3_client.return_value.restore_object.called
+        for exc in [exceptions.RestoreAlreadyInProgressError('blah'),
+                    exceptions.AlreadyRestoredError('blah')]:
+            self.mock_get_s3_client.reset_mock()
+            assert not self.mock_get_s3_client.return_value.restore_object.called
+            self.mock_get_s3_client.return_value.restore_object.side_effect = exc
+            S3Path('s3://bucket/key/obj').restore()
+            assert self.mock_get_s3_client.return_value.restore_object.called
 
 
 class TestS3File(S3TestCase):


### PR DESCRIPTION
* Add ``stor.S3Path.restore(days, tier)`` to restore objects from Glacier to S3.
  Paired with this change are two specific exceptions related to S3 restores,
  ``RestoreAlreadyInProgressError`` (raised when restore has already started)
  and ``AlreadyRestoredError`` (raised when restoring object already in S3).
* Move ``ConflictError`` to ``stor.exceptions`` (still available under ``stor.swift``)

@pkaleta @kyleabeauchamp cc @wesleykendall 