### PR TITLE
Only allow bytes for write_object in Python 3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v3.0.0
+------
+
+API Breaks
+^^^^^^^^^^
+
+* ``write_object()`` *only* allows ``bytes`` data in Python 3 (it will raise a
+  ``TypeError`` otherwise). Behavior in Python 2 is unchanged.
+
 v2.1.3
 ------
 

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -829,7 +829,9 @@ class DXPath(OBSPath):
         if not self.resource:
             raise ValueError('Cannot write to project. Please provide a file path')
         if not isinstance(content, bytes):  # pragma: no cover
-            warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
+                # bytes/unicode a little confused so allow it
+                warnings.warn('Python 3 stor and a future Python 2 version of stor will raise a'
+                              ' TypeError if content is not bytes')
         mode = 'wb' if type(content) == bytes else 'wt'
         if self.isfile():
             self.remove()

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -488,7 +488,8 @@ class S3Path(OBSPath):
         if not isinstance(content, bytes):  # pragma: no cover
             if six.PY2:
                 # bytes/unicode a little confused so allow it
-                warnings.warn('future versions of stor (and Python 3) will raise a TypeError if content is not bytes')
+                warnings.warn('Python 3 stor and a future Python 2 version of stor will raise a'
+                              ' TypeError if content is not bytes')
             else:
                 raise TypeError('write_object() expects bytes, not text data')
         mode = 'wb' if isinstance(content, bytes) else 'w'

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -486,7 +486,11 @@ class S3Path(OBSPath):
             content (bytes): raw bytes to write to OBS
         """
         if not isinstance(content, bytes):  # pragma: no cover
-            warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
+            if six.PY2:
+                # bytes/unicode a little confused so allow it
+                warnings.warn('future versions of stor (and Python 3) will raise a TypeError if content is not bytes')
+            else:
+                raise TypeError('write_object() expects bytes, not text data')
         mode = 'wb' if isinstance(content, bytes) else 'w'
         with tempfile.NamedTemporaryFile(mode) as fp:
             fp.write(content)

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -664,7 +664,8 @@ class SwiftPath(OBSPath):
         if not isinstance(content, bytes):  # pragma: no cover
             if six.PY2:
                 # bytes/unicode a little confused so allow it
-                warnings.warn('future versions of stor (and Python 3) will raise a TypeError if content is not bytes')
+                warnings.warn('Python 3 stor and a future Python 2 version of stor will raise a'
+                              ' TypeError if content is not bytes')
             else:
                 raise TypeError('write_object() expects bytes, not text data')
         mode = 'wb' if type(content) == bytes else 'wt'

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -662,7 +662,11 @@ class SwiftPath(OBSPath):
                 `SwiftPath.upload`
         """
         if not isinstance(content, bytes):  # pragma: no cover
-            warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
+            if six.PY2:
+                # bytes/unicode a little confused so allow it
+                warnings.warn('future versions of stor (and Python 3) will raise a TypeError if content is not bytes')
+            else:
+                raise TypeError('write_object() expects bytes, not text data')
         mode = 'wb' if type(content) == bytes else 'wt'
         with tempfile.NamedTemporaryFile(mode=mode) as fp:
             fp.write(content)


### PR DESCRIPTION
@anujkumar93 to review

Only allow bytes for write_object in Python 3. Motivation is to prevent latent programming bugs (since this is essentially required for Python 3 writing to buffers anyways).

I think this may break dxpy3 a bit, but right now it's already broken for Python 3 file object reading/writing...