### PR TITLE
Simplify open arguments

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v3.0.0
+------
+
+API Breaks
+^^^^^^^^^^
+
+* ``swift_upload_kwargs``  / ``swift_upload_options`` are no longer allowed in ``OBSFile()`` or ``stor.open()``
+* The only permitted arguments/keyword arguments to ``open()`` are now ``mode`` and ``encoding``.
+
 v2.1.3
 ------
 

--- a/docs/swift.rst
+++ b/docs/swift.rst
@@ -34,7 +34,7 @@ SwiftPath
 
   .. automethod:: copy(dest, swift_retry_args=None)
 
-  .. automethod:: copytree(dest, copy_cmd='cp -r', swift_upload_options=None, swift_download_options=None)
+  .. automethod:: copytree(dest, copy_cmd='cp -r')
 
   .. automethod:: upload(to_upload, segment_size=DEFAULT_SEGMENT_SIZE, use_slo=True, segment_container=None, leave_segments=False, changed=False, object_name=None, object_threads=10, segment_threads=10, condition=None, use_manifest=False, \**retry_args)
 

--- a/stor/base.py
+++ b/stor/base.py
@@ -262,7 +262,7 @@ class Path(text_type):
         """
         return self.path_class(self.path_module.join(self, *others))
 
-    def open(self, *args, **kwargs):
+    def open(self, mode=None, encoding=None):
         """Open a file-like object.
 
         The only cross-compatible arguments for this function are listed below.
@@ -371,7 +371,7 @@ class FileSystemPath(Path):
     In particular: allows changing directory when used as contextmanager and
     wraps Python's builtin open() to be compatible with swift_upload_args.
     """
-    def open(self, *args, **kwargs):
+    def open(self, mode=None, encoding=None):
         """
         Opens a path and retains interface compatibility with
         `SwiftPath` by popping the unused ``swift_upload_args`` keyword
@@ -379,9 +379,13 @@ class FileSystemPath(Path):
 
         Creates parent directory if it does not exist.
         """
-        kwargs.pop('swift_upload_kwargs', None)
         self.parent.makedirs_p()
-        return builtins.open(self, *args, **kwargs)
+        kwargs = {}
+        if mode:
+            kwargs['mode'] = mode
+        if encoding:
+            kwargs['encoding'] = encoding
+        return builtins.open(self, **kwargs)
 
     def __enter__(self):
         self._old_dir = os.getcwd()

--- a/stor/base.py
+++ b/stor/base.py
@@ -380,11 +380,8 @@ class FileSystemPath(Path):
         Creates parent directory if it does not exist.
         """
         self.parent.makedirs_p()
-        kwargs = {}
-        if mode:
-            kwargs['mode'] = mode
-        if encoding:
-            kwargs['encoding'] = encoding
+        # only set kwargs if they aren't set to avoid overwriting defaults
+        kwargs = {k: v for k, v in [('mode', mode), ('encoding', encoding)] if v}
         return builtins.open(self, **kwargs)
 
     def __enter__(self):

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -358,7 +358,7 @@ class OBSFile(object):
     # to know whether we need to close the underlying buffer
     _buffer = None
 
-    def __init__(self, pth, mode='r', encoding=None, **kwargs):
+    def __init__(self, pth, mode='r', encoding=None):
         """Initializes a file object
 
         Args:
@@ -379,7 +379,6 @@ class OBSFile(object):
             raise TypeError('encoding not supported in Python 2')
         self._path = pth
         self.mode = mode
-        self._kwargs = kwargs
         self.encoding = encoding or locale.getpreferredencoding(False)
 
     def __enter__(self):

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -486,4 +486,4 @@ class OBSFile(object):
         if self.mode == 'w':
             self._path.write_object(self._buffer.getvalue().encode(self.encoding))
         else:
-            self._path.write_object(self._buffer.getvalue(), **self._kwargs)
+            self._path.write_object(self._buffer.getvalue())

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -646,7 +646,7 @@ class SwiftPath(OBSPath):
                                  '&'.join(query),
                                  auth_url_parts.fragment))
 
-    def write_object(self, content, **swift_upload_args):
+    def write_object(self, content):
         """Writes an individual object.
 
         Note that this method writes the provided content to a temporary
@@ -658,8 +658,6 @@ class SwiftPath(OBSPath):
 
         Args:
             content (bytes): raw bytes to write to OBS
-            **swift_upload_args: Keyword arguments to pass to
-                `SwiftPath.upload`
         """
         if not isinstance(content, bytes):  # pragma: no cover
             warnings.warn('future versions of stor will raise a TypeError if content is not bytes')
@@ -668,7 +666,7 @@ class SwiftPath(OBSPath):
             fp.write(content)
             fp.flush()
             suo = OBSUploadObject(fp.name, object_name=self.resource)
-            return self.upload([suo], **swift_upload_args)
+            return self.upload([suo])
 
     @_swift_retry(exceptions=(ConditionNotMetError, UnavailableError))
     def list(self,

--- a/stor/tests/test_posix.py
+++ b/stor/tests/test_posix.py
@@ -205,19 +205,12 @@ class TestCopytree(unittest.TestCase):
 
 
 class TestOpen(unittest.TestCase):
-    def test_open_works_w_swift_params(self):
-        with tempfile.NamedTemporaryFile() as f:
-            p = Path(f.name).open(swift_upload_kwargs={
-                'use_slo': True
-            })
-            p.close()
-
     def test_functional_open(self):
         with tempfile.NamedTemporaryFile() as f:
             with stor.open(f.name, 'w', swift_upload_kwargs={}) as f:
                 f.write('blah')
 
-    def test_open_works_wo_swift_params(self):
+    def test_open_works(self):
         with tempfile.NamedTemporaryFile() as f:
             p = stor.Path(f.name).open()
             p.close()

--- a/stor/tests/test_posix.py
+++ b/stor/tests/test_posix.py
@@ -207,7 +207,7 @@ class TestCopytree(unittest.TestCase):
 class TestOpen(unittest.TestCase):
     def test_functional_open(self):
         with tempfile.NamedTemporaryFile() as f:
-            with stor.open(f.name, 'w', swift_upload_kwargs={}) as f:
+            with stor.open(f.name, 'w') as f:
                 f.write('blah')
 
     def test_open_works(self):


### PR DESCRIPTION
Some additional API breaks to round out changes you already started @anujkumar93

* ``swift_upload_kwargs``  / ``swift_upload_options`` are no longer allowed in ``OBSFile()`` or ``stor.open()``
* The only permitted arguments/keyword arguments to ``open()`` are now ``mode`` and ``encoding``.

Haven't had chance to test but will test it in a final round of DX testing...