### PR TITLE
open fix for swift and s3

### DIFF
--- a/stor/obs.py
+++ b/stor/obs.py
@@ -166,7 +166,8 @@ class OBSPath(Path):
             DNAnexusError: A dxpy client error occured.
             RemoteError: A s3 client error occurred.
         """
-        if six.PY3 and encoding and encoding not in ('utf-8', 'utf8'):  # pragma: no cover
+        if six.PY3 and encoding and encoding not in ('utf-8', 'utf8') and \
+                isinstance(self, stor.dx.DXPath):  # pragma: no cover
             raise ValueError('For DNAnexus paths in Python 3, encoding is always assumed to be '
                              'utf-8. Please switch your encoding or Python version')
         return OBSFile(self, mode=mode, encoding=encoding)


### PR DESCRIPTION
During fixing encoding issues for Python 3 and DX Paths, I overlooked that for swift and s3 paths, open is also delegated to OBSPath. Hence, the encoding check should only be for DX Paths in particular.