### PR TITLE
Docs and manifest update after splitting packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
 include AUTHORS
 include LICENSE
 include README.md
-include requirements*.txt
-include stor/default.cfg
-include stor/default.env
-include stor/stor-completion.bash
-prune stor/tests
+include stor*/requirements*.txt
+include stor/stor/default.cfg
+include stor/stor/default.env
+include stor/stor/stor-completion.bash
+prune stor*/stor*/tests
 exclude Makefile

--- a/docs/package_split.rst
+++ b/docs/package_split.rst
@@ -7,7 +7,8 @@ which handles posix and windows (local) paths, and the plugins ``stor_dx``, ``st
 function as stand-alone packages. This may be changed in the future.
 
 The legacy version of stor was implemented as one monolith which supported dx, swift, s3, etc, but
-was changed due to extraneous dependencies and modular requirements. This page describes these changes.
+was changed due to extraneous dependencies and modular requirements. Stor now supports multiple backends
+flexibly, so that only required dependencies need to be installed. This page describes these changes.
 
 
 Implementation
@@ -26,30 +27,12 @@ Typically, this function is called ``class_for_path`` in ``stor_dx``, ``stor_s3`
         dx = stor_dx:class_for_path
 
 
-Each plugin currently raises an error if the prefix provided is not the prefix it supports. For
+A plugin must implement a single function that takes in A(prefix) and B(str) and returns a tuple of
+(C(class), D(str)),  then it can be registered with ``stor.providers``. The prefix determines the path
+prefix that the plugin in question would support, and the paths stor would forward to the plugin. For
 example, ``stor_dx.class_for_path`` errors if the prefix is not ``dx``. In addition, ``class_for_path``
 in each plugin module can assume that the prefix argument is truly the prefix to the path argument as
 this is guaranteed by the core ``stor`` package. Future plugins will be implemented in this fashion.
-
-
-Code Changes
-------------
-
-The following code blocks and functions were affected when shifting legacy stor to a modular version.
-
-`stor.copy`, `stor.copytree` and ``stor.open`` which were earlier present in the core ``stor.utils`` and
-``stor.obs`` are now split according to their individual functions into the three plugin packages.
-These functions in the core package now only deal with posix/windows paths while the three plugins
-implement the finer aspects of the logic individual to each platform. The external effect of
-these changes is that `stor.copy` and `stor.copytree` which used to support ``source`` kwarg argument in
-legacy stor, instead now expect an initial argument to be a ``Path | str``, which is then taken to be the
-source to be copied from. The destination is decided by the ``dest`` kwarg as in legacy stor.
-
-``is_swift_path`` has been removed from the core `stor` package. Thus, using ``stor.is_swift_path`` will
-fail. This is because the plugins determine the prefix they support and the core package cannot know in
-advance if ``swift://`` is a supported path. In cases where ``stor.is_swift_path`` was being used,
-``stor.is_obs_path`` is a possible substitution. Thus, each individual plugin ``stor_dx``, ``stor_s3`` and
-``stor_swift`` is now responsible for supporting ``is_dx_path``, ``is_s3_path`` and ``is_swift_path`` resp.
 
 
 Versioning

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -22,6 +22,22 @@ API Breaks
 * ``is_swift_path`` has been removed from the core ``stor`` package. Hence, ``stor.is_swift_path`` is no
   longer supported. Can use `stor.is_obs_path` in such cases after consideration.
 
+Code Changes
+------------
+
+The following code blocks and functions were affected when shifting legacy stor to a modular version.
+
+* `stor.copy`, `stor.copytree` and ``stor.open`` which were earlier present in the core ``stor.utils`` and
+  ``stor.obs`` are now split according to their individual functions into the three plugin packages.
+  These functions in the core package now only deal with posix/windows paths while the three plugins
+  implement the finer aspects of the logic individual to each platform.
+* ``is_swift_path`` has been removed because the plugins determine the prefix they support and the core
+  package cannot know in advance if ``swift://`` is a supported path. In cases where ``stor.is_swift_path``
+  was being used, ``stor.is_obs_path`` is a possible substitution, given the initial intent was to check
+  against cloud paths. Thus, each individual plugin ``stor_dx``, ``stor_s3`` and ``stor_swift`` is now
+  responsible for supporting ``is_dx_path``, ``is_s3_path`` and ``is_swift_path`` resp.
+
+
 v3.0.0
 ------
 

--- a/stor/MANIFEST.in
+++ b/stor/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include requirements*.txt
+include stor/default.cfg
+include stor/default.env
+include stor/stor-completion.bash
+prune stor/tests

--- a/stor_dx/MANIFEST.in
+++ b/stor_dx/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements*.txt
+prune stor_dx/tests

--- a/stor_dx/stor_dx/__init__.py
+++ b/stor_dx/stor_dx/__init__.py
@@ -3,11 +3,8 @@ from stor_dx.dx import DXPath
 from stor_dx import utils
 
 
-drive = DXPath.drive
-
-
 def class_for_path(prefix, path):
-    if prefix+'://' != drive:
+    if prefix+'://' != DXPath.drive:
         raise ValueError('Invalid prefix to initialize DXPaths: {}'.format(prefix))
     cls = utils.find_dx_class(path)
     return cls, path

--- a/stor_s3/MANIFEST.in
+++ b/stor_s3/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements*.txt
+prune stor_s3/tests

--- a/stor_s3/stor_s3/__init__.py
+++ b/stor_s3/stor_s3/__init__.py
@@ -2,11 +2,8 @@ from stor_s3.utils import is_s3_path
 from stor_s3.s3 import S3Path
 
 
-drive = S3Path.drive
-
-
 def class_for_path(prefix, path):
-    if prefix+'://' != drive:
+    if prefix+'://' != S3Path.drive:
         raise ValueError('Invalid prefix to initialize S3Paths: {}'.format(prefix))
     cls = S3Path
     return cls, path

--- a/stor_swift/MANIFEST.in
+++ b/stor_swift/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements*.txt
+prune stor_swift/tests

--- a/stor_swift/stor_swift/__init__.py
+++ b/stor_swift/stor_swift/__init__.py
@@ -2,12 +2,8 @@ from stor_swift.utils import is_swift_path
 from stor_swift.swift import SwiftPath
 
 
-
-drive = SwiftPath.drive
-
-
 def class_for_path(prefix, path):
-    if prefix+'://' != drive:
+    if prefix+'://' != SwiftPath.drive:
         raise ValueError('Invalid prefix to initialize SwiftPaths: {}'.format(prefix))
     cls = SwiftPath
     return cls, path


### PR DESCRIPTION
@jtratner 

This PR handles the docs, left-over review comments and any other nuances that crept up after splitting the stor packages into 4 modules.

## Background

This is a continuation of the story to split stor across 4 modules : stor, stor_dx, stor_swift, stor_s3. This is done to easy the dependencies that need to be installed to use a particular fact of stor, and to make it more modular. This PR is preceded by https://github.com/counsyl/stor/pull/101 for this story, and will be followed by a PR to generate requirements.txt dynamically to pin versions.

## Changes

- package_split.rst is updated to not have release_notes language, and hopefully makes things clearer

- Manifests were added for each individual package, after checking with devpi. Have not removed the manifest at the top level, though maybe probably should.

## Tested via:

The testing suite was run after the changes successfully, including the integration testing suite.

## TODOS

- Dynamically generate requirements.txt of stor in sdist, to have the proper version of stor_dx, stor_swift, stor_s3, etc.