### PR TITLE
Fix for normpath for DXPath

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v3.0.1
+------
+
+* Fixed `normpath` functionality for ``DXPath`` (i.e., ``DXVirtualPath`` and ``DXCanonicalPath``)
+  when no resource present in provided path.
+
 v3.0.0
 ------
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 v3.0.1
 ------
 
-* Fixed `normpath` functionality for ``DXPath`` (i.e., ``DXVirtualPath`` and ``DXCanonicalPath``)
+* Fixed `DXPath.normpath` functionality  (i.e., for ``DXVirtualPath`` and ``DXCanonicalPath``)
   when no resource present in provided path.
 
 v3.0.0

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -1170,7 +1170,7 @@ class DXVirtualPath(DXPath):
             resource=(self.canonical_resource or '')))
 
     def normpath(self):
-        normed_resource = self.path_module.normpath('/' + self.resource)[1:]
+        normed_resource = self.path_module.normpath('/' + (self.resource or ''))[1:]
         norm_pth = self.path_class(self.drive + self.project + ':/' + normed_resource)
         if isinstance(norm_pth, DXCanonicalPath):
             return norm_pth.normpath()
@@ -1221,4 +1221,4 @@ class DXCanonicalPath(DXPath):
         return self
 
     def normpath(self):
-        return self.path_class(self.drive + self.project + ':' + self.resource)
+        return self.path_class(self.drive + self.project + ':' + (self.resource or ''))

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -142,8 +142,14 @@ class TestCompatHelpers(unittest.TestCase):
                          DXPath('dx://project:/'))
         self.assertEqual(DXPath('dx://project:///..//..///..').normpath(),
                          DXPath('dx://project:/'))
+        self.assertEqual(DXPath('dx://project:/a/b').normpath(),
+                         DXPath('dx://project:/a/b'))
         self.assertEqual(DXPath('dx://project:a/b').normpath(),
                          DXPath('dx://project:/a/b'))
+        self.assertEqual(DXPath('dx://project:/').normpath(),
+                         DXPath('dx://project:/'))
+        self.assertEqual(DXPath('dx://project:').normpath(),
+                         DXPath('dx://project:/'))
         # ../ on root should not change project
         self.assertEqual(DXPath(
             'dx://project-123456789012345678901234:../file-123456789012345678901234'
@@ -156,6 +162,8 @@ class TestCompatHelpers(unittest.TestCase):
         ).normpath(),
              DXPath(
                  'dx://project-123456789012345678901234:file-123456789012345678901234'))
+        self.assertEqual(DXPath('dx://project-123456789012345678901234:/').normpath(),
+                         DXPath('dx://project-123456789012345678901234:'))
 
 
 class TestRename(DXTestCase):


### PR DESCRIPTION
@jtratner @pkaleta 

This PR fixes the normpath bug in DXVirtualPath and DXCanonicalPath

## Background
Stor had a bug for DXPaths, wherein paths like DXPath('dx://project:/').normpath() errored with `TypeError: cannot concatenate 'str' and 'NoneType' objects`. This is because for such paths, the resource turns out to be None, which is then attempted to add it to a string '/' in normpath.

## Changes
- Fixed the normpath function in DXVirtualPath and DXCanonicalPath through `self.resource or ''`
- Added tests for normpath

## Tested via:
- Test suite was run successfully