### PR TITLE
Add functionality in stor to query available DNAnexus projects

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v3.0.3
+------
+
+* ``stor dx-find-projects`` and ``DXPath.find_projects`` are added to query the list of DNAnexus
+  projects available to the stor user.
+
 v3.0.2
 ------
 

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -96,7 +96,8 @@ from stor import Path
 from stor import utils
 from stor.extensions import swiftstack
 
-PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url', 'convert-swiftstack')
+PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url', 'convert-swiftstack',
+              'dx-find-projects')
 SERVICES = ('s3', 'swift', 'dx')
 
 ENV_FILE = os.path.expanduser('~/.stor-cli.env')
@@ -303,6 +304,11 @@ def _convert_swiftstack(path, bucket=None):
         raise ValueError("invalid path for conversion: '%s'" % path)
 
 
+def _find_dx_projects(name=None, level=None):
+    from stor.dx import DXPath
+    return DXPath.find_projects(name=name, level=level)
+
+
 def create_parser():
     parser = argparse.ArgumentParser(description='A command line interface for stor.')
 
@@ -414,6 +420,12 @@ def create_parser():
     parser_swiftstack.add_argument('path')
     parser_swiftstack.add_argument('--bucket', default=None)
     parser_swiftstack.set_defaults(func=_convert_swiftstack)
+
+    parser_find_dx_projects = subparsers.add_parser('dx-find-projects',
+                                                    help='find DX projects user has access to')
+    parser_find_dx_projects.add_argument('--level')
+    parser_find_dx_projects.add_argument('--name')
+    parser_find_dx_projects.set_defaults(func=_find_dx_projects)
 
     return parser
 

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -128,6 +128,24 @@ class DXPath(OBSPath):
     realpath = _noop('realpath')
     expanduser = _noop('expanduser')
 
+    @classmethod
+    def find_projects(cls, name=None, level=None):
+        """
+        Class level function to find out projects the user has access to
+
+        Args:
+            name (string): String on which to glob project names
+            level (string): The time (in seconds) the temporary
+                URL will be valid
+        """
+        kwargs = {'describe': {'fields': {'name': True}}}
+        if name:
+            kwargs.update(name='*'+name+'*',
+                          name_mode='glob')
+        if level:
+            kwargs.update(level=level)
+        return list(dxpy.bindings.search.find_projects(**kwargs))
+
     def clear_cached_properties(self):
         """Clears all cached properties in DXPath objects.
 

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import contextlib
-import json
 import os
 import mock
 import sys

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -1803,3 +1803,13 @@ class TestLoginAuth(DXTestCase):
                 self.assertEqual(mock_auth.call_count, 1)
         self.test_dir.makedirs_p()
         self.assertTrue(self.test_dir.isdir())
+
+
+class TestFindUserProjects(unittest.TestCase):
+    def test_find_projects(self):
+        with mock.patch('dxpy.bindings.search.find_projects') as mock_auth:
+            expected_value = [{'id': 'project-123456789012345678901234', 'level': 'VIEW',
+                               'permissionSources': ['user_org'], 'public': False}]
+            mock_auth.return_value=expected_value
+            user_projects = DXPath.find_projects()
+            self.assertEqual(user_projects, expected_value)


### PR DESCRIPTION
@pkaleta @jtratner 

This PR adds capability in stor to query available DNAnexus projects for the user and adds tests for it

## Changes
- Added function in DXPath and cli to query available projects on DNAnexus. stor has a new endpoint dx-find-projects
- Added tests.

## Tested via:
- Test suite was run successfully

## TODO:
- Run integration tests once all bugs are fixed / features are added