### PR TITLE
updating dxpy3 to dxpy

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v3.0.5
+------
+* Changed dxpy3 requirement to dxpy to reflect Python3 updates to dxpy
+
 v3.0.4
 ------
 * Fix release notes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ requests!=2.12.2,!=2.13.0,>=2.10.0
 boto3>=1.4.0
 cached-property
 contextlib2
-dxpy>=0.265.0; python_version <= '2.7'
-dxpy3; python_version > '3.0'
+dxpy>=0.278.0
 python-keystoneclient>=1.8.1
 python-swiftclient
 six

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -802,8 +802,7 @@ class DXPath(OBSPath):
 
     def read_object(self):
         """Reads an individual object from DX.
-
-        Note dxpy3 automatically decodes the DXFile.read using
+        Note dxpy for Py3 automatically decodes the DXFile.read using utf-8.
 
         Returns:
             bytes: the raw bytes from the object on DX.
@@ -815,8 +814,8 @@ class DXPath(OBSPath):
         with _wrap_dx_calls():
             result = file_handler.read()
         if six.PY3:  # pragma: no cover
-            # TODO (akumar): allow other encoding after update of dxpy3
-            result = result.encode('utf-8')  # dxpy3 already decodes the data with 'utf-8'
+            # TODO (akumar): allow other encoding after update of encoding in dxpy for Py3
+            result = result.encode('utf-8')  # dxpy for py3 already decodes the data with 'utf-8'
         return result
 
     def write_object(self, content, **kwargs):

--- a/stor/tests/test_integration_dx.py
+++ b/stor/tests/test_integration_dx.py
@@ -147,7 +147,7 @@ class DXIntegrationTest(BaseIntegrationTest.BaseTestCases, DXTestCase):
 
     def test_custom_encoding_text(self):
         # explicit encoding is only supported for py3 in general
-        # dxpy3 assumes the encoding is utf-8. can't support other encoding for dx
+        # dxpy py3 assumes the encoding is utf-8. can't support other encoding for dx
         pass
 
     def test_over_100_files(self):
@@ -273,7 +273,7 @@ class DXIntegrationTest(BaseIntegrationTest.BaseTestCases, DXTestCase):
                     time.sleep(.5)
                 self.assertFalse((self.test_dir / which_obj).exists())
 
-    @skipIf(six.PY3, 'dxpy3 assumes utf-8 encoding, not suitable for gzip')
+    @skipIf(six.PY3, 'dxpy py3 assumes utf-8 encoding, not suitable for gzip')
     def test_gzip_on_remote(self):
         self._skip_if_filesystem_python3(self.test_dir)
         local_gzip = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
@jtratner CC @pkaleta 

Since DNAnexus has integrated dxpy3 into dxpy, makes sense to get rid of dxpy3 from stor.

Passed unit and integration tests.