### PR TITLE
Add canonicalize flag to cli functions list ls walkfiles

### DIFF
--- a/docs/dx.rst
+++ b/docs/dx.rst
@@ -98,6 +98,10 @@ individual details are explained further below.
      - Returns [filepath]
      - Returns [filepath]
      - Returns []
+   * - listdir on non-existent folder
+     - Returns []
+     - Returns []
+     - Raises NotFoundError
    * - copy, target exists and is file
      - Overwrites the file
      - Overwrites the file
@@ -185,6 +189,14 @@ copy and copytree behave differently when the target output path exists and is a
       - dx://newproject/all/trip-photos
 
 Note that if the output path exists and is a file, the file will be *overwritten*
+
+
+List, Listdir and walkfiles
+---------------------------
+``stor ls``, ``stor list`` and ``stor walkfiles`` for DXPaths take in a ``--canonicalize``
+flag which returns the results with canonical dxIDs instead of human readable virtual
+paths. This is especially useful for manipulating paths directly using dx-toolkit
+through piping. This flag is ignored when passed for other paths (swift/s3/posix).
 
 Open on stor
 ------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v3.0.3
+------
+* Add ``--canonicalize`` flag to ``stor list``, ``stor ls`` and ``stor walkfiles`` cli commands
+
 v3.0.2
 ------
 

--- a/stor/base.py
+++ b/stor/base.py
@@ -407,7 +407,7 @@ class FileSystemPath(Path):
             return path
         return path.decode(sys.getfilesystemencoding(), 'surrogateescape')
 
-    def listdir(self):
+    def listdir(self, **kwargs):
         """D.listdir() -> List of items in this directory.
 
         The elements of the list are Path objects.
@@ -572,7 +572,7 @@ class FileSystemPath(Path):
                 raise
         return self
 
-    def walkfiles(self, pattern=None, errors='strict'):  # flake8: noqa pragma: no cover 
+    def walkfiles(self, pattern=None, errors='strict', **kwargs):  # flake8: noqa pragma: no cover
         """ D.walkfiles() -> iterator over files in D, recursively.
         The optional argument `pattern` limits the results to files
         with names that match the pattern.  For example,

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -332,6 +332,16 @@ def create_parser():
                              help='Limit the amount of results returned.',
                              type=int,
                              metavar='INT')
+    canonicalize_parser = parser_list.add_mutually_exclusive_group(required=False)
+    canonicalize_parser.add_argument('--canonicalize',
+                                     help='Canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_true')
+    canonicalize_parser.add_argument('--no-canonicalize',
+                                     help='Dont canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_false')
+    parser_list.set_defaults(canonicalize=False)
     parser_list.set_defaults(func=_wrapped_list)
 
     ls_msg = 'List path as a directory.'
@@ -339,6 +349,16 @@ def create_parser():
                                       help=ls_msg,
                                       description=ls_msg)
     parser_ls.add_argument('path', type=get_path, metavar='PATH')
+    canonicalize_parser = parser_ls.add_mutually_exclusive_group(required=False)
+    canonicalize_parser.add_argument('--canonicalize',
+                                     help='Canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_true')
+    canonicalize_parser.add_argument('--no-canonicalize',
+                                     help='Dont canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_false')
+    parser_ls.set_defaults(canonicalize=False)
     parser_ls.set_defaults(func=stor.listdir)
 
     cp_msg = 'Copy a source to a destination path.'
@@ -381,6 +401,16 @@ def create_parser():
                                   type=str,
                                   metavar='REGEX')
     parser_walkfiles.add_argument('path', type=get_path, metavar='PATH')
+    canonicalize_parser = parser_walkfiles.add_mutually_exclusive_group(required=False)
+    canonicalize_parser.add_argument('--canonicalize',
+                                     help='Canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_true')
+    canonicalize_parser.add_argument('--no-canonicalize',
+                                     help='Dont canonicalize any DXPaths that are returned',
+                                     dest='canonicalize',
+                                     action='store_false')
+    parser_walkfiles.set_defaults(canonicalize=False)
     parser_walkfiles.set_defaults(func=stor.walkfiles)
 
     cat_msg = 'Output file contents to stdout.'

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -332,16 +332,10 @@ def create_parser():
                              help='Limit the amount of results returned.',
                              type=int,
                              metavar='INT')
-    canonicalize_parser = parser_list.add_mutually_exclusive_group(required=False)
-    canonicalize_parser.add_argument('--canonicalize',
-                                     help='Canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_true')
-    canonicalize_parser.add_argument('--no-canonicalize',
-                                     help='Dont canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_false')
-    parser_list.set_defaults(canonicalize=False)
+    parser_list.add_argument('--canonicalize',
+                             help='Canonicalize any DXPaths that are returned',
+                             dest='canonicalize',
+                             action='store_true')
     parser_list.set_defaults(func=_wrapped_list)
 
     ls_msg = 'List path as a directory.'
@@ -349,16 +343,10 @@ def create_parser():
                                       help=ls_msg,
                                       description=ls_msg)
     parser_ls.add_argument('path', type=get_path, metavar='PATH')
-    canonicalize_parser = parser_ls.add_mutually_exclusive_group(required=False)
-    canonicalize_parser.add_argument('--canonicalize',
-                                     help='Canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_true')
-    canonicalize_parser.add_argument('--no-canonicalize',
-                                     help='Dont canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_false')
-    parser_ls.set_defaults(canonicalize=False)
+    parser_ls.add_argument('--canonicalize',
+                           help='Canonicalize any DXPaths that are returned',
+                           dest='canonicalize',
+                           action='store_true')
     parser_ls.set_defaults(func=stor.listdir)
 
     cp_msg = 'Copy a source to a destination path.'
@@ -401,16 +389,10 @@ def create_parser():
                                   type=str,
                                   metavar='REGEX')
     parser_walkfiles.add_argument('path', type=get_path, metavar='PATH')
-    canonicalize_parser = parser_walkfiles.add_mutually_exclusive_group(required=False)
-    canonicalize_parser.add_argument('--canonicalize',
-                                     help='Canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_true')
-    canonicalize_parser.add_argument('--no-canonicalize',
-                                     help='Dont canonicalize any DXPaths that are returned',
-                                     dest='canonicalize',
-                                     action='store_false')
-    parser_walkfiles.set_defaults(canonicalize=False)
+    parser_walkfiles.add_argument('--canonicalize',
+                                  help='Canonicalize any DXPaths that are returned',
+                                  dest='canonicalize',
+                                  action='store_true')
     parser_walkfiles.set_defaults(func=stor.walkfiles)
 
     cat_msg = 'Output file contents to stdout.'

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -231,7 +231,7 @@ class OBSPath(Path):
     def stat(self):
         raise NotImplementedError
 
-    def walkfiles(self, pattern=None):
+    def walkfiles(self, pattern=None, **kwargs):
         """Iterate over files recursively.
 
         Args:

--- a/stor/posix.py
+++ b/stor/posix.py
@@ -20,7 +20,7 @@ class PosixPath(base.FileSystemPath):
     """
     path_module = posixpath
 
-    def list(self):
+    def list(self, **kwargs):
         """
         List all files and directories under a path.
 
@@ -29,7 +29,7 @@ class PosixPath(base.FileSystemPath):
         """
         return list(utils.walk_files_and_dirs([self]).keys())
 
-    def walkfiles(self, pattern=None):
+    def walkfiles(self, pattern=None, **kwargs):
         """Iterate over files recursively.
 
         Args:

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -232,7 +232,8 @@ class S3Path(OBSPath):
              use_manifest=False,
              # hidden args
              list_as_dir=False,
-             ignore_dir_markers=False):
+             ignore_dir_markers=False,
+             **kwargs):
         """
         List contents using the resource of the path as a prefix.
 
@@ -306,9 +307,9 @@ class S3Path(OBSPath):
         utils.check_condition(condition, list_results)
         return list_results
 
-    def listdir(self):
+    def listdir(self, **kwargs):
         """List the path as a dir, returning top-level directories and files."""
-        return self.list(list_as_dir=True)
+        return self.list(list_as_dir=True, **kwargs)
 
     def exists(self):
         """

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -682,7 +682,8 @@ class SwiftPath(OBSPath):
              # intentionally not documented
              list_as_dir=False,
              ignore_segment_containers=True,
-             ignore_dir_markers=False):
+             ignore_dir_markers=False,
+             **kwargs):
         """List contents using the resource of the path as a prefix.
 
         This method retries ``num_retries`` times if swift is unavailable
@@ -766,13 +767,17 @@ class SwiftPath(OBSPath):
         utils.check_condition(condition, paths)
         return paths
 
-    def listdir(self, ignore_segment_containers=True):
+    def listdir(self, ignore_segment_containers=True, **kwargs):
         """Lists the path as a dir, returning top-level directories and files
 
         For information about retry logic on this method, see
         `SwiftPath.list`
         """
-        return self.list(list_as_dir=True, ignore_segment_containers=ignore_segment_containers)
+        return self.list(
+            list_as_dir=True,
+            ignore_segment_containers=ignore_segment_containers,
+            **kwargs
+        )
 
     @_swift_retry(exceptions=(ConditionNotMetError, UnavailableError))
     def glob(self, pattern, condition=None):
@@ -1487,7 +1492,7 @@ class SwiftPath(OBSPath):
             return False
 
     @_swift_retry(exceptions=UnavailableError)
-    def walkfiles(self, pattern=None):
+    def walkfiles(self, pattern=None, **kwargs):
         """Iterates over listed files that match an optional pattern.
 
         Args:

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -336,23 +336,14 @@ class TestList(BaseCliTest):
             S3Path('s3://some-bucket/b')
         ]]
 
-        self.parse_args('stor list s3://some-bucket -s dir --canonicalize')
+        self.parse_args('stor list s3://some-bucket -s dir -l2 --canonicalize')
         self.assertEquals(sys.stdout.getvalue(),
                           's3://some-bucket/dir/a\n'
                           's3://some-bucket/dir/b\n'
                           's3://some-bucket/dir/c/d\n')
 
-        # clear stdout
-        sys.stdout = six.StringIO()
-
-        self.parse_args('stor list s3://some-bucket -l2 --no-canonicalize')
-        self.assertEquals(sys.stdout.getvalue(),
-                          's3://some-bucket/a\n'
-                          's3://some-bucket/b\n')
-
         mock_list.assert_has_calls([
-            mock.call(S3Path('s3://some-bucket'), starts_with='dir', canonicalize=True),
-            mock.call(S3Path('s3://some-bucket'), limit=2)
+            mock.call(S3Path('s3://some-bucket'), starts_with='dir', limit=2, canonicalize=True)
         ])
 
     @mock.patch.object(S3Path, 'list', autospec=True)

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -336,7 +336,7 @@ class TestList(BaseCliTest):
             S3Path('s3://some-bucket/b')
         ]]
 
-        self.parse_args('stor list s3://some-bucket -s dir')
+        self.parse_args('stor list s3://some-bucket -s dir --canonicalize')
         self.assertEquals(sys.stdout.getvalue(),
                           's3://some-bucket/dir/a\n'
                           's3://some-bucket/dir/b\n'
@@ -345,13 +345,13 @@ class TestList(BaseCliTest):
         # clear stdout
         sys.stdout = six.StringIO()
 
-        self.parse_args('stor list s3://some-bucket -l2')
+        self.parse_args('stor list s3://some-bucket -l2 --no-canonicalize')
         self.assertEquals(sys.stdout.getvalue(),
                           's3://some-bucket/a\n'
                           's3://some-bucket/b\n')
 
         mock_list.assert_has_calls([
-            mock.call(S3Path('s3://some-bucket'), starts_with='dir'),
+            mock.call(S3Path('s3://some-bucket'), starts_with='dir', canonicalize=True),
             mock.call(S3Path('s3://some-bucket'), limit=2)
         ])
 
@@ -390,6 +390,20 @@ class TestLs(BaseCliTest):
                           'swift://t/c/dir/\n'
                           'swift://t/c/file3\n')
         mock_listdir.assert_called_once_with(SwiftPath('swift://t/c'))
+
+    @mock.patch.object(SwiftPath, 'listdir', autospec=True)
+    def test_listdir_swift_options(self, mock_listdir):
+        mock_listdir.return_value = [
+            SwiftPath('swift://t/c/file1'),
+            SwiftPath('swift://t/c/dir/'),
+            SwiftPath('swift://t/c/file3')
+        ]
+        self.parse_args('stor ls swift://t/c --canonicalize')
+        self.assertEquals(sys.stdout.getvalue(),
+                          'swift://t/c/file1\n'
+                          'swift://t/c/dir/\n'
+                          'swift://t/c/file3\n')
+        mock_listdir.assert_called_once_with(SwiftPath('swift://t/c'), canonicalize=True)
 
 
 @mock.patch('stor.copy', autospec=True)
@@ -490,6 +504,20 @@ class TestWalkfiles(BaseCliTest):
                           './c.txt\n'
                           './d.txt\n')
         mock_walkfiles.assert_called_once_with(PosixPath('.'), pattern='*.txt')
+
+    @mock.patch.object(PosixPath, 'walkfiles', autospec=True)
+    def test_walkfiles_posix_options(self, mock_walkfiles):
+        mock_walkfiles.return_value = [
+            './a/b.txt',
+            './c.txt',
+            './d.txt'
+        ]
+        self.parse_args('stor walkfiles -p=*.txt . --canonicalize')
+        self.assertEquals(sys.stdout.getvalue(),
+                          './a/b.txt\n'
+                          './c.txt\n'
+                          './d.txt\n')
+        mock_walkfiles.assert_called_once_with(PosixPath('.'), pattern='*.txt', canonicalize=True)
 
     @mock.patch.object(PosixPath, 'walkfiles', autospec=True)
     def test_walkfiles_no_pattern(self, mock_walkfiles):


### PR DESCRIPTION
@jtratner CC @pkaleta 

This PR adds the canonicalize flag to list, ls and walkfiles options in the cli. Adding this flag will help in manipulating DX paths and resources. I had to add kwargs to function definitions of these 3 commands for swift, s3, posix to not break any apis. I added a few tests to depict nothing breaks for other paths even if we pass canonicalize flag. For DXPaths, I checked that the canonicalized paths are returned. For folders, the project is canonicalized, and the path to folder stays.

```
akumar$ stor ls dx://HMM_CNV_Test --canonicalize
dx://project-FK8pJ100x54yqG4x7XyK62v2:/StorTesting
dx://project-FK8pJ100x54yqG4x7XyK62v2:/parent
dx://project-FK8pJ100x54yqG4x7XyK62v2:/workflow-FPx2PgQ0x54Yq7pbBQ2Gf87K
dx://project-FK8pJ100x54yqG4x7XyK62v2:/applet-FPx2PgQ0x54bVqVzBQBZ0KGq
dx://project-FK8pJ100x54yqG4x7XyK62v2:/applet-FPx2Pg00x54V7kKFBVX9kQx8
dx://project-FK8pJ100x54yqG4x7XyK62v2:/file-FPJ5kyj0x54q55GP0z3x8Yyj
dx://project-FK8pJ100x54yqG4x7XyK62v2:/file-FK9FG600x54b37J3FF41K1Zy
```