### PR TITLE
Enable empty path dx:// for DXPath initialization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Jeff Tratner @jtratner
 Stephanie Huang @phanieste
 Kyle Beauchamp @kyleabeauchamp
 Piotr Kaleta @pkaleta
+Anuj Kumar @anujkumar93

--- a/stor/tests/cassettes_py2/TestCopy/test_empty_path.yaml
+++ b/stor/tests/cassettes_py2/TestCopy/test_empty_path.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: !!python/unicode '{"name": "TestCopy.test_empty_path.3cc6f518"}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP480b103x9yg6QGfJKqX"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397649322-318481
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPP480b103x9yg6QGfJKqX/describe
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP480b103x9yg6QGfJKqX","name":"TestCopy.test_empty_path.3cc6f518","class":"project","created":1553397649000,"modified":1553397649000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '646'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397649422-673067
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPP480b103x9yg6QGfJKqX/destroy
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP480b103x9yg6QGfJKqX"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397649574-967006
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/cassettes_py2/TestCopyTree/test_empty_path.yaml
+++ b/stor/tests/cassettes_py2/TestCopyTree/test_empty_path.yaml
@@ -1,0 +1,139 @@
+interactions:
+- request:
+    body: !!python/unicode '{"name": "TestCopyTree.test_empty_path.4662e943"}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP6801YyXv3Q32v06xKyz"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397657042-395806
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPP6801YyXv3Q32v06xKyz/describe
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP6801YyXv3Q32v06xKyz","name":"TestCopyTree.test_empty_path.4662e943","class":"project","created":1553397657000,"modified":1553397657000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '650'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397657159-954225
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{"name": "TestCopyTree.test_empty_path.4662e943", "limit":
+      2, "level": "VIEW"}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: !!python/unicode '{"results":[{"id":"project-FXFPP6801YyXv3Q32v06xKyz","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:20:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397657258-552246
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Content-Type:
+      - application/json
+      DNAnexus-API:
+      - 1.0.0
+      User-Agent:
+      - dxpy/0.278.0 (Darwin-18.2.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPP6801YyXv3Q32v06xKyz/destroy
+  response:
+    body:
+      string: !!python/unicode '{"id":"project-FXFPP6801YyXv3Q32v06xKyz"}'
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 24 Mar 2019 03:21:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - Express
+      x-request-id:
+      - 1553397657388-926446
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/cassettes_py3/TestCopy/test_empty_path.yaml
+++ b/stor/tests/cassettes_py3/TestCopy/test_empty_path.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{"name": "TestCopy.test_empty_path.994f5d14"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: '{"id":"project-FXFPPvj0149kYBBKKYQ8fFBq"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:27 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397747593-485230
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPPvj0149kYBBKKYQ8fFBq/describe
+  response:
+    body:
+      string: '{"id":"project-FXFPPvj0149kYBBKKYQ8fFBq","name":"TestCopy.test_empty_path.994f5d14","class":"project","created":1553397747000,"modified":1553397747000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '646'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:27 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397747717-35921
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPPvj0149kYBBKKYQ8fFBq/destroy
+  response:
+    body:
+      string: '{"id":"project-FXFPPvj0149kYBBKKYQ8fFBq"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:30 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397747835-841730
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/cassettes_py3/TestCopyTree/test_empty_path.yaml
+++ b/stor/tests/cassettes_py3/TestCopyTree/test_empty_path.yaml
@@ -1,0 +1,195 @@
+interactions:
+- request:
+    body: '{"name": "TestCopyTree.test_empty_path.65567609"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: '{"id":"project-FXFPPyQ0jYB4q5Gp6f4BZG8p"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:34 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397754818-377843
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPPyQ0jYB4q5Gp6f4BZG8p/describe
+  response:
+    body:
+      string: '{"id":"project-FXFPPyQ0jYB4q5Gp6f4BZG8p","name":"TestCopyTree.test_empty_path.65567609","class":"project","created":1553397754000,"modified":1553397754000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '650'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:34 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397754921-608919
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestCopyTree.test_empty_path.65567609", "level": "VIEW", "limit":
+      2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-FXFPPyQ0jYB4q5Gp6f4BZG8p","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:35 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397755023-459488
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          YmVhcmVyIFNPVXE2end1b05MdGRCOUdEVTZYWE0wZzMzTEVhRlhw
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjIuMC14ODZfNjQtaTM4Ni02NGJp
+          dCk=
+    method: POST
+    uri: https://api.dnanexus.com/project-FXFPPyQ0jYB4q5Gp6f4BZG8p/destroy
+  response:
+    body:
+      string: '{"id":"project-FXFPPyQ0jYB4q5Gp6f4BZG8p"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 24 Mar 2019 03:22:37 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1553397755153-701205
+      X-Upgrade-Info:
+      - A recommended update (v0.278.0) is available for your client/SDK. You can
+        download it from https://wiki.dnanexus.com/Downloads#Install
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -39,6 +39,9 @@ class TestBasicPathMethods(unittest.TestCase):
         p2 = Path('dx://project:/')
         self.assertEqual(p2.dirname(), 'dx://project:/')
 
+        p3 = Path('dx://')
+        self.assertEqual(p3.dirname(), 'dx://')
+
     def test_basename(self):
         p = Path('dx://project:/path/to/resource')
         self.assertEqual(p.basename(), 'resource')
@@ -66,9 +69,9 @@ class TestPathManipulations(unittest.TestCase):
 
 
 class TestProject(unittest.TestCase):
-    def test_project_none(self):
-        with pytest.raises(ValueError, match='Project is required'):
-            DXPath('dx://')
+    def test_no_project(self):
+        dx_p = DXPath('dx://')
+        self.assertIsNone(dx_p.project)
 
     def test_project_exists(self):
         dx_p = DXPath('dx://project')
@@ -79,9 +82,14 @@ class TestProject(unittest.TestCase):
         self.assertEqual(dx_p.project, 'project')
         dx_p = DXPath('dx://project:/')
         self.assertEqual(dx_p.project, 'project')
+        dx_p = DXPath('dx://project-123456789012345678901234:/file')
+        self.assertEqual(dx_p.project, 'project-123456789012345678901234')
 
 
 class TestResource(unittest.TestCase):
+    def test_no_resource_empty(self):
+        dx_p = DXPath('dx://')
+        self.assertIsNone(dx_p.resource)
 
     def test_resource_none_w_project(self):
         dx_p = DXPath('dx://project:/')
@@ -168,6 +176,11 @@ class TestCompatHelpers(unittest.TestCase):
 
 
 class TestRename(DXTestCase):
+    def test_rename_empty_fail(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='cannot be renamed'):
+            dx_p._rename('RandomProject2:')
+
     def test_rename_project_fail(self):
         dx_p = DXPath('dx://Random_Project:/')
         with pytest.raises(ValueError, match='cannot be renamed'):
@@ -199,6 +212,15 @@ class TestRename(DXTestCase):
 class TestOpen(DXTestCase):
     # we need to give enough time for file to enter `closed` state so we can read it
     DX_WAIT_SETTINGS = {'dx': {'wait_on_close': 20}}
+
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='on a file path'):
+            with dx_p.open() as f:
+                f.read()
+        with pytest.raises(ValueError, match='Cannot write to provided path'):
+            with dx_p.open(mode='w') as f:
+                f.write('random text')
 
     def test_append_mode_fail(self):
         self.setup_temporary_project()
@@ -288,13 +310,13 @@ line4
         with pytest.raises(exceptions.NotFoundError, match='No data object'):
             dx_p.open().read()
         dx_p = DXPath('dx://' + self.project)
-        with pytest.raises(ValueError, match='not a project'):
+        with pytest.raises(ValueError, match='on a file path'):
             dx_p.open().read()
 
     def test_write_to_project_fail(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)
-        with pytest.raises(ValueError, match='Cannot write to project'):
+        with pytest.raises(ValueError, match='Cannot write to provided path'):
             with dx_p.open(mode='wb') as f:
                 f.write(b'data')
 
@@ -337,6 +359,11 @@ class TestDXOBSFile(SharedOBSFileCases, unittest.TestCase):
 
 
 class TestCanonicalProject(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.canonical_project
+
     def test_no_project(self):
         dx_p = DXPath('dx://Random_Project:/')
         with pytest.raises(dx.ProjectNotFoundError, match='no projects'):
@@ -378,6 +405,11 @@ class TestCanonicalProject(DXTestCase):
 
 
 class TestCanonicalResource(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.canonical_resource
+
     def test_no_resource(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project + ':/random.txt')
@@ -413,6 +445,32 @@ class TestCanonicalResource(DXTestCase):
 
 
 class TestListDir(DXTestCase):
+    @mock.patch('dxpy.find_projects')
+    def test_empty_path(self, mock_find_projects):
+        mock_find_projects.return_value = [
+            {'id': 'project-123', 'describe': {'name': 'Project1'}},
+            {'id': 'project-456', 'describe': {'name': 'Project2'}}
+        ]
+        dx_p = DXPath('dx://')
+        results = dx_p.listdir()
+        self.assert_dx_lists_equal(results, ['dx://Project1:', 'dx://Project2:'])
+
+        results = list(dx_p.listdir_iter())
+        self.assert_dx_lists_equal(results, ['dx://Project1:', 'dx://Project2:'])
+
+    @mock.patch('dxpy.find_projects')
+    def test_empty_path_canonicalize(self, mock_find_projects):
+        mock_find_projects.return_value = [
+            {'id': 'project-123', 'describe': {'name': 'Project1'}},
+            {'id': 'project-456', 'describe': {'name': 'Project2'}}
+        ]
+        dx_p = DXPath('dx://')
+        results = dx_p.listdir(canonicalize=True)
+        self.assert_dx_lists_equal(results, ['dx://project-123:', 'dx://project-456:'])
+
+        results = list(dx_p.listdir_iter(canonicalize=True))
+        self.assert_dx_lists_equal(results, ['dx://project-123:', 'dx://project-456:'])
+
     def test_listdir_project(self):
         self.setup_temporary_project()
         self.setup_files(['/temp_folder/folder_file.txt',
@@ -514,6 +572,13 @@ class TestListDir(DXTestCase):
 
 
 class TestList(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='not supported'):
+            dx_p.list()
+        with pytest.raises(ValueError, match='not supported'):
+            list(dx_p.list_iter())
+
     def test_list_project(self):
         self.setup_temporary_project()
         self.setup_files(['/temp_folder/folder_file.txt',
@@ -664,6 +729,11 @@ class TestList(DXTestCase):
 
 
 class TestWalkFiles(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='not supported'):
+            list(dx_p.walkfiles())
+
     def test_pattern_w_prefix(self):
         self.setup_temporary_project()
         self.setup_files(['/temp_folder/folder_file.txt',
@@ -714,6 +784,11 @@ class TestWalkFiles(DXTestCase):
 
 
 class TestStat(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.stat()
+
     def test_stat_folder(self):
         self.setup_temporary_project()
         self.setup_files(['/temp_folder/folder_file.csv'])
@@ -769,6 +844,11 @@ class TestStat(DXTestCase):
 
 
 class TestExists(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.exists()
+
     def test_false_file(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://'+self.project+':/random.txt')
@@ -813,6 +893,11 @@ class TestExists(DXTestCase):
 
 
 class TestGlob(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='not supported'):
+            dx_p.glob('*')
+
     def test_suffix_pattern(self):
         self.setup_temporary_project()
         self.setup_files(['/temp_folder/folder_file.txt',
@@ -879,10 +964,15 @@ class TestGlob(DXTestCase):
 
 
 class TestTempUrl(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='need path resource'):
+            dx_p.temp_url()
+
     def test_fail_on_project(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)
-        with pytest.raises(ValueError, match='DX Projects'):
+        with pytest.raises(ValueError, match='need path resource'):
             dx_p.temp_url()
 
     def test_fail_on_folder(self):
@@ -926,6 +1016,11 @@ class TestTempUrl(DXTestCase):
 
 
 class TestRemove(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='can only be called on single object'):
+            dx_p.remove()
+
     def test_remove_file(self):
         self.setup_temporary_project()
         f = self.setup_file('/temp_file.txt')
@@ -989,6 +1084,11 @@ class TestRemove(DXTestCase):
 
 
 class TestMakedirsP(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.makedirs_p()
+
     def test_makedirs_p_project(self):
         with pytest.raises(ValueError, match='Cannot create a project'):
             DXPath('dx://project:').makedirs_p()
@@ -1033,6 +1133,11 @@ class TestMakedirsP(DXTestCase):
 
 
 class TestDownloadObjects(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(ValueError, match='Cannot call download_objects on empty path'):
+            dx_p.download_objects(DXPath('dx://some-proj:'), ['file1.txt'])
+
     def test_local_paths(self):
         self.setup_temporary_project()
         self.setup_file('/temp_folder/file1.txt')
@@ -1084,6 +1189,17 @@ class TestDownloadObjects(DXTestCase):
 
 
 class TestCopy(DXTestCase):
+    def test_empty_path(self):
+        self.setup_temporary_project()
+        dx_p = DXPath('dx://')
+        dest = DXPath('dx://' + self.project)
+        with pytest.raises(exceptions.NotFoundError, match='No data object was found'):
+            dx_p.copy(dest)
+        with pytest.raises(ValueError):
+            dx_p._clone(dest)
+        with pytest.raises(ValueError):
+            dx_p._move(dest)
+
     def test_clone_move_project_fail(self):
         self.setup_temporary_project()
         self.setup_file('/folder_file.txt')
@@ -1386,6 +1502,17 @@ class TestCopy(DXTestCase):
 
 
 class TestCopyTree(DXTestCase):
+    def test_empty_path(self):
+        self.setup_temporary_project()
+        dx_p = DXPath('dx://')
+        dest = DXPath('dx://' + self.project)
+        with pytest.raises(exceptions.NotFoundError, match='No project or directory was found'):
+            dx_p.copytree(dest)
+        with pytest.raises(NotImplementedError):
+            dx_p._clonetree(dest)
+        with pytest.raises(NotImplementedError):
+            dx_p._movetree(dest)
+
     def test_clonetree_within_project_fail(self):
         self.setup_temporary_project()
         self.setup_file('/temp_folder/folder_file.txt')
@@ -1709,6 +1836,11 @@ class TestCopyTree(DXTestCase):
 
 
 class TestUpload(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.upload(['.'])
+
     def test_upload_files_existing(self):
         self.setup_temporary_project()
         self.setup_file('/folder/file2.txt')
@@ -1731,6 +1863,11 @@ class TestUpload(DXTestCase):
 
 
 class TestGetSize(DXTestCase):
+    def test_empty_path(self):
+        dx_p = DXPath('dx://')
+        with pytest.raises(NotImplementedError):
+            dx_p.getsize()
+
     def test_project(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)

--- a/stor/tests/test_dx_path_compat.py
+++ b/stor/tests/test_dx_path_compat.py
@@ -17,8 +17,12 @@ class TestBasics(unittest.TestCase):
             DXPath(None)
 
     def test_construction_from_no_project(self):
-        with pytest.raises(ValueError, match='Project is required to construct a DXPath'):
-            DXPath('dx://')
+        dx_p = DXPath('dx://')
+        self.assertEqual(dx_p, 'dx://')
+
+    def test_construction_no_project_fail(self):
+        with self.assertRaises(ValueError):
+            DXPath('dx:///folder')
 
     def test_canonical_construct_fail(self):
         with pytest.raises(ValueError, match='ambiguous'):

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -274,7 +274,9 @@ def find_dx_class(p):
     """
     from stor.dx import DXPath, DXCanonicalPath, DXVirtualPath
     colon_pieces = p[len(DXPath.drive):].split(':', 1)
-    if not colon_pieces or not colon_pieces[0] or '/' in colon_pieces[0]:
+    if not colon_pieces or not colon_pieces[0]:
+        return DXPath
+    if '/' in colon_pieces[0]:
         raise ValueError('Project is required to construct a DXPath')
     project = colon_pieces[0]
     resource = (colon_pieces[1] if len(colon_pieces) == 2 else '').lstrip('/')


### PR DESCRIPTION
@jtratner CC @pkaleta 

## Background

This PR enables initialization of dx:// as a DXPath. We want to allow initialization of `dx://` to be able to call listdir on it and see the projects the user has access to. `stor ls dx://` will list such projects.

## Changes

- Changed DXPath initialization logic in utils to provision for dx://
- Handled logic in all DXPath function to allow for dx://
- Added tests for dx:// for all DXPath functions

### Other unrelated tiny changes in this PR:
- Added splitpath in DXPath. Had moved it earlier to individual subclasses but needed a declaration in DXPath too
- Added my name to AUTHORS :)