### PR TITLE
Fix required version of six package.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+v3.0.4
+------
+* Fix required version of ``six`` package. We need at least 1.9.0, because we're using ``six.raise_from``.
+
 v3.0.3
 ------
 * Add ``--canonicalize`` flag to ``stor list``, ``stor ls`` and ``stor walkfiles`` cli commands

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ dxpy>=0.265.0; python_version <= '2.7'
 dxpy3; python_version > '3.0'
 python-keystoneclient>=1.8.1
 python-swiftclient
-six
+six>=1.9.0


### PR DESCRIPTION
@jtratner cc @anujkumar93 

`six.raise_from`, which we use a lot was added in `six-1.9.0`. We need to require at least this version in requirements.txt.