### PR TITLE
Add content_type property for OBS paths

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,12 +4,17 @@ Release Notes
 v3.1.0
 ------
 
+API Additions
+^^^^^^^^^^^^^
+
 * Implement ``readable()``, ``writable()``, and ``seekable()`` methods on
   ``OBSFile`` so it better implements ``io.IOBase`` specification.
+* Added ``content_type`` property for OBS paths representing consistent
+  Content-Type header that would be set on download.
 
 v3.0.5
 ------
-* Changed dxpy3 requirement to dxpy to reflect Python3 updates to dxpy
+* Changed ``dxpy3`` requirement to ``dxpy`` to reflect new Python3 compatible ``dxpy`` module.
 
 v3.0.4
 ------

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -1087,6 +1087,11 @@ class DXPath(OBSPath):
         return dxpy.DXFile(dxid=self.canonical_resource,
                            project=self.canonical_project).describe()
 
+    @property
+    def content_type(self):
+        """Get content type for DXObject. Returns empty string if not present or is project/"""
+        return self.stat().get('media') or ''
+
 
 class DXVirtualPath(DXPath):
     """Class Handler for DXPath of form 'dx://MyProject:/a/b/c' or 'dx://project-{uuid}:/b/c'"""

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -231,6 +231,13 @@ class OBSPath(Path):
     def stat(self):
         raise NotImplementedError
 
+    @property
+    def content_type(self):
+        """Returns content type, as a string, if present and makes sense for object type.
+
+        Returns Empty string otherwise"""
+        raise NotImplementedError
+
     def walkfiles(self, pattern=None, **kwargs):
         """Iterate over files recursively.
 

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -468,6 +468,11 @@ class S3Path(OBSPath):
         }
         return response
 
+    @property
+    def content_type(self):
+        """Get content type for path (using ContentType field from Boto) or empty string."""
+        return self.stat().get('ContentType', '')
+
     def read_object(self):
         """Read an individual object from OBS.
 

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -1423,6 +1423,11 @@ class SwiftPath(OBSPath):
         contract)"""
         return int(self.stat().get('Content-Length', 0))
 
+    @property
+    def content_type(self):
+        """Returns content-type. Empty string if not set or if an account or container"""
+        return self.stat().get('Content-Type') or ''
+
     @_swift_retry(exceptions=(UnavailableError, UnauthorizedError))
     def post(self, options=None):
         """Post operations on the path.

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -219,4 +219,3 @@ class SharedOBSFileCases(object):
         self.assertFalse(write_obj.readable())
         self.assertTrue(write_obj.writable())
         self.assertTrue(write_obj.seekable())
-       

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -1830,3 +1830,30 @@ class TestLoginAuth(DXTestCase):
                 self.assertEqual(mock_auth.call_count, 1)
         self.test_dir.makedirs_p()
         self.assertTrue(self.test_dir.isdir())
+
+
+class TestContentType(DXTestCase):
+    @mock.patch.object(DXPath, 'stat')
+    def test_content_type(self, mock_stat):
+        mock_stat.return_value = {
+            u'archivalState': u'live',
+            u'class': u'file',
+            u'created': 1563329954000,
+            u'createdBy': {u'user': u'user-someuser'},
+            u'folder': u'/',
+            u'hidden': False,
+            u'id': u'file-234092349023490290239398',
+            u'links': [],
+            u'media': u'text/plain',
+            u'modified': 1563329955907,
+            u'name': u'somefile.txt',
+            u'project': u'project-123456823409234902309423',
+            u'size': 6,
+            u'sponsored': False,
+            u'state': u'closed',
+            u'tags': [],
+            u'types': []
+        }
+        self.assertEqual(DXPath('dx://P:/C/T').content_type, 'text/plain')
+        mock_stat.return_value = {}
+        self.assertEqual(DXPath('dx://P:/C/T').content_type, '')

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1605,3 +1605,23 @@ class TestS3ErrorParsing(unittest.TestCase):
         obj = s3._parse_s3_error(ClientError(error_response, u'RestoreObject'),
                                  Bucket='BUCKETNAME', Key='KEYNAME')
         self.assertIsInstance(obj, exceptions.AlreadyRestoredError)
+
+
+class TestContentType(S3TestCase):
+    @mock.patch.object(S3Path, 'stat')
+    def test_content_type(self, mock_stat):
+        mock_stat.return_value = {
+            'AcceptRanges': 'bytes',
+            'ContentEncoding': '',
+            'ContentLength': 2331425,
+            'ContentType': 'text/csv',
+            'ETag': '"smthing"',
+            'LastModified': datetime.datetime(2018, 4, 10, 7, 5, 18),
+            'Metadata': {'mtime': '1234'},
+            'ServerSideEncryption': 'AES256',
+            'StorageClass': 'GLACIER',
+            'VersionId': 'someid'
+        }
+        self.assertEqual(S3Path('s3://A/C/T').content_type, 'text/csv')
+        mock_stat.return_value = {}
+        self.assertEqual(S3Path('s3://A/C/T').content_type, '')

--- a/stor/tests/test_swift.py
+++ b/stor/tests/test_swift.py
@@ -2653,3 +2653,27 @@ class TestExceptionParsing(unittest.TestCase):
             http_host='swift.counsyl.com', http_status=403, msg='Object GET failed')
         with self.assertRaises(exceptions.ObjectInColdStorageError):
             swift._swiftclient_error_to_descriptive_exception(exc)
+
+
+class TestContentType(SwiftTestCase):
+    @mock.patch.object(SwiftPath, 'stat')
+    def test_content_type(self, mock_stat):
+        mock_stat.return_value = {
+            'Account': u'AUTH_whatever',
+            'Container': u'some-container',
+            'Content-Length': u'1234',
+            'Content-Type': u'text/csv',
+            'ETag': u'etag',
+            'Last-Modified': u'Tue, 10 Apr 2018 07:05:18 GMT',
+            'Manifest': None,
+            'Object': stor.Path('mypath'),
+            'headers': {
+                'accept-ranges': 'bytes',
+                'content-encoding': '',
+                'content-length': '1234',
+                'content-type': 'text/csv'
+            }
+        }
+        self.assertEqual(SwiftPath('swift://A/C/T').content_type, 'text/csv')
+        mock_stat.return_value = {}
+        self.assertEqual(SwiftPath('swift://A/C/T').content_type, '')


### PR DESCRIPTION
@anujkumar93  @pkaleta - adds `content_type` property for all OBS paths.

Kinda annoying to figure out what content-type header should be set to
consistently - adding method helps with that.

Sem-Ver: feature