### PR TITLE
Python 3.4 is EOL - long live python 3.7!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: python
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 install:
   - make setup
 script:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 v3.1.0
 ------
 
+* Added python 3.7 to test suite, removed EOL python 3.4
+
 API Additions
 ^^^^^^^^^^^^^
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Development Status :: 5 - Production/Stable
     Operating System :: OS Independent
 


### PR DESCRIPTION
Switch out python3.4 in favor of 3.7 in Travis for testing.