### PR TITLE
added readable, writable, and seekable methods to OBSFile to fully implement the io.IOBase interface

### DIFF
--- a/stor/obs.py
+++ b/stor/obs.py
@@ -488,3 +488,12 @@ class OBSFile(object):
             self._path.write_object(self._buffer.getvalue().encode(self.encoding))
         else:
             self._path.write_object(self._buffer.getvalue())
+
+    def readable(self):
+        return self.mode in self._READ_MODES
+
+    def writable(self):
+        return self.mode in self._WRITE_MODES
+
+    def seekable(self):
+        return True

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -211,17 +211,11 @@ class SharedOBSFileCases(object):
     def test_readable_writable_seekable(self):
         pth = self.normal_path
         read_obj = pth.open(mode='r')
-        self.assertTrue(hasattr(read_obj, 'readable'))
-        self.assertTrue(hasattr(read_obj, 'writable'))
-        self.assertTrue(hasattr(read_obj, 'seekable'))
         self.assertTrue(read_obj.readable())
         self.assertFalse(read_obj.writable())
         self.assertTrue(read_obj.seekable())
 
         write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
-        self.assertTrue(hasattr(write_obj, 'readable'))
-        self.assertTrue(hasattr(write_obj, 'writable'))
-        self.assertTrue(hasattr(write_obj, 'seekable'))
         self.assertFalse(write_obj.readable())
         self.assertTrue(write_obj.writable())
         self.assertTrue(write_obj.seekable())

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -207,3 +207,21 @@ class SharedOBSFileCases(object):
             obj.seek(0)
         mock_write_object.assert_called_with(self.normal_path, b'happy-go_lucky')
         self.assertEquals(len(mock_write_object.call_args_list), 1)
+
+    def test_readable_writable_seekable(self):
+        pth = self.normal_path
+        read_obj = pth.open(mode='r')
+        self.assertTrue(hasattr(read_obj, 'readable'))
+        self.assertTrue(hasattr(read_obj, 'writable'))
+        self.assertTrue(hasattr(read_obj, 'seekable'))
+        self.assertTrue(read_obj.readable())
+        self.assertFalse(read_obj.writable())
+        self.assertTrue(read_obj.seekable())
+
+        write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
+        self.assertTrue(hasattr(write_obj, 'readable'))
+        self.assertTrue(hasattr(write_obj, 'writable'))
+        self.assertTrue(hasattr(write_obj, 'seekable'))
+        self.assertFalse(write_obj.readable())
+        self.assertTrue(write_obj.writable())
+        self.assertTrue(write_obj.seekable())

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -208,26 +208,15 @@ class SharedOBSFileCases(object):
         mock_write_object.assert_called_with(self.normal_path, b'happy-go_lucky')
         self.assertEquals(len(mock_write_object.call_args_list), 1)
 
-    def test_readable(self):
+    def test_readable_writable_seekable(self):
         pth = self.normal_path
         read_obj = pth.open(mode='r')
         self.assertTrue(read_obj.readable())
-
-        write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
-        self.assertFalse(write_obj.readable())
-
-    def test_writable(self):
-        pth = self.normal_path
-        read_obj = pth.open(mode='r')
         self.assertFalse(read_obj.writable())
-
-        write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
-        self.assertTrue(write_obj.writable())
-
-    def test_seekable(self):
-        pth = self.normal_path
-        read_obj = pth.open(mode='r')
         self.assertTrue(read_obj.seekable())
 
         write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
+        self.assertFalse(write_obj.readable())
+        self.assertTrue(write_obj.writable())
         self.assertTrue(write_obj.seekable())
+       

--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -208,14 +208,26 @@ class SharedOBSFileCases(object):
         mock_write_object.assert_called_with(self.normal_path, b'happy-go_lucky')
         self.assertEquals(len(mock_write_object.call_args_list), 1)
 
-    def test_readable_writable_seekable(self):
+    def test_readable(self):
         pth = self.normal_path
         read_obj = pth.open(mode='r')
         self.assertTrue(read_obj.readable())
-        self.assertFalse(read_obj.writable())
-        self.assertTrue(read_obj.seekable())
 
         write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
         self.assertFalse(write_obj.readable())
+
+    def test_writable(self):
+        pth = self.normal_path
+        read_obj = pth.open(mode='r')
+        self.assertFalse(read_obj.writable())
+
+        write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
         self.assertTrue(write_obj.writable())
+
+    def test_seekable(self):
+        pth = self.normal_path
+        read_obj = pth.open(mode='r')
+        self.assertTrue(read_obj.seekable())
+
+        write_obj = stor.open(stor.join(self.drive, 'B/C/obj'), 'w')
         self.assertTrue(write_obj.seekable())


### PR DESCRIPTION
- added `readable`, `writable`, and `seekable` methods to `OBSFile`
- tests that OBS objects opened for reading and writing:
  - have the readable/writable/seekable methods
  - returns True for seekable
  - returns True for `readable`, False for `writable` when opened for reading
  - returns False for `readable`, True for `writable` when opened for writing