### PR TITLE
lint: removed blank line

### DIFF
--- a/stor/tests/shared_obs.py
+++ b/stor/tests/shared_obs.py
@@ -219,4 +219,3 @@ class SharedOBSFileCases(object):
         self.assertFalse(write_obj.readable())
         self.assertTrue(write_obj.writable())
         self.assertTrue(write_obj.seekable())
-       


### PR DESCRIPTION
Blank line at end of test file caused lint failure, preventing go/cd deployment.