### PR TITLE
Fix logic around calling wait_on_close

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,13 @@ API Additions
 * Added ``content_type`` property for OBS paths representing consistent
   Content-Type header that would be set on download.
 
+Bug Fixes
+^^^^^^^^^
+
+* Only call ``OBSFile._wait_on_close()`` when we actually wrote data AND we
+  were in write mode. Also fixes issues where malformed ``OBSFile`` objects
+  would throw an exception in ``__del__`` method.
+
 v3.0.5
 ------
 * Changed ``dxpy3`` requirement to ``dxpy`` to reflect new Python3 compatible ``dxpy`` module.

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -457,11 +457,12 @@ class OBSFile(object):
         if self._buffer:
             if self.mode in self._WRITE_MODES:
                 self.flush()
+                # we want to wait_on_close on DXPath only if no error was thrown while writing the
+                # file
+                if not any(sys.exc_info()):  # pragma: no cover
+                    self._wait_on_close()
             self._buffer.close()
         self.closed = True
-        # we want to wait_on_close on DXPath only if no error was thrown while writing the file
-        if not any(sys.exc_info()):  # pragma: no cover
-            self._wait_on_close()
 
     def _wait_on_close(self):
         if isinstance(self._path, stor.dx.DXPath):


### PR DESCRIPTION
1. Only call it when we've written data (i.e., there's a buffer) - fixes
   issues where destructor was throwing errors. (came up when watching travis logs)
2. Only call it for WRITE_MODES (this should potential issue where
   holding a DX file object in read mode would cause an extra API
   request).

I'd like to double check this, but my belief on reading this is that we were previously making an additional API request to DNAnexus every time we attempted to read a DXFile object (rather than only doing it on writes).