### PR TITLE
For discussion: Do not block when garbage collecting OBSFile's

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -18,6 +18,8 @@ Bug Fixes
 * Only call ``OBSFile._wait_on_close()`` when we actually wrote data AND we
   were in write mode. Also fixes issues where malformed ``OBSFile`` objects
   would throw an exception in ``__del__`` method.
+* Do not ever ``wait_on_close`` when write happened in ``__del__`` method (so
+  no accidental blocking of main thread).
 
 v3.0.5
 ------

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -405,7 +405,7 @@ class OBSFile(object):
         return self
 
     def __del__(self):
-        self.close()
+        self.close(_block=False)
 
     @property
     def stream_cls(self):
@@ -451,7 +451,11 @@ class OBSFile(object):
     def name(self):
         return self._path
 
-    def close(self):
+    def close(self, _block=True):
+        """Close file object.
+
+        ``_block`` keyword argument is for internal use only. End-users should set dx:wait_on_close
+        to False to prevent blocking."""
         if self.closed:
             return
         if self._buffer:
@@ -459,7 +463,7 @@ class OBSFile(object):
                 self.flush()
                 # we want to wait_on_close on DXPath only if no error was thrown while writing the
                 # file
-                if not any(sys.exc_info()):  # pragma: no cover
+                if _block and not any(sys.exc_info()):  # pragma: no cover
                     self._wait_on_close()
             self._buffer.close()
         self.closed = True


### PR DESCRIPTION
Really only makes sense in ``__exit__()`` (i.e., when used in ``with``
statement).

Otherwise I think you can hang main thread in a `gc` block by accident.

Thoughts on this @anujkumar93 @pkaleta ?