### PR TITLE
Add support for DNAnexus file proxy/http serving

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 env:
   POETRY_VERSION: 1.0
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 env:
   POETRY_VERSION: 1.0
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,6 +19,21 @@ API Additions
   for more detail).
 * Added ``content_type`` property for OBS paths representing consistent
   Content-Type header that would be set on download.
+* Added ``DX_FILE_PROXY_URL`` and ``[dx] -> file_proxy_url`` setting to allow for constructing
+  DNAnexus paths with a custom gateway.  You might want this to be able to construct valid bam
+  paths for samtools or IGV!
+
+  Generally, usage will look like::
+
+    $ stor url dx://proj:/folder/mypath.csv
+    https://dl.dnanex.us/F/D/awe1323/mypath.csv
+    $ export DX_FILE_PROXY_URL=https://my-dnax-proxy.example.com/gateway
+    $ stor url dx://proj:/folder/mypath.csv
+    https://my-dnax-proxy.example.com/gateway/proj/folder/mypath.csv
+
+  Interested in your own file proxy gateway? Email support@dnanexus.com to request it! :)
+  Also, you can contact the Bioinformatics Software Engineering team at Myriad Genetics
+  to ask to share code.
 
 API Breaks
 ^^^^^^^^^^
@@ -37,6 +52,8 @@ Bug Fixes
   were in write mode.
 * Eliminate exception in ``__del__`` method when calling ``stor.open`` on a DNAnexus project path.
 * ``stor.open()`` now throws an error earlier when incorrectly calling ``open()`` on a DNAnexus project path.
+* Now ``temp_url()`` always sets filename to virtual object name when creating temp urls, matching the docstring.
+  To get the old (buggy!) behavior, pass ``filename=''`` to ``temp_url()``
 
 Developer Changes
 ^^^^^^^^^^^^^^^^^

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -41,7 +41,7 @@ Settings can be configured in the following ways in order of precedence:
 
 2. Setting environment variables.
 
-3. User-specified configuration in a ``~/stor.cfg`` file.
+3. User-specified configuration in a ``~/.stor.cfg`` file.
 
 
 Default Settings

--- a/stor/default.cfg
+++ b/stor/default.cfg
@@ -131,3 +131,10 @@ auth_token =
 # wait_on_close (int): The number of seconds to wait for DXFile to go to
 # closed state. Passed to DXFile.wait_on_close
 wait_on_close = 0
+
+# file_proxy_url (str): A custom proxy service for dx paths. It's assumed that
+#   you can construct URLs as urljoin({file_proxy_url}, f'{project}/{resource}').
+#   If this is set, temp_url() will generate HTTP paths using the proxy;
+#   otherwise it'll use make_download_url().
+#   May also set via DX_FILE_PROXY_URL env var as well.
+file_proxy_url =

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -191,7 +191,7 @@ class DXPath(OBSPath):
             >>> stor.Path('dx://proj:/folder/mypath.csv').temp_url()
             'https://dl.dnanex.us/F/D/awe1323/mypath.csv'
             >>> with stor.settings.use({'dx': {'file_proxy_url':
-            ...     'https://myproxy.example.com/gateway'}):
+            ...     'https://my-dnax-proxy.example.com/gateway'}):
             ... stor.Path('dx://proj:/folder/mypath.csv').temp_url()
             'https://my-dnax-proxy.example.com/gateway/proj/folder/mypath.csv'
 
@@ -208,7 +208,7 @@ class DXPath(OBSPath):
         Raises:
             ValueError: The path points to a project
             ValueError: ``file_proxy_url`` is set and ``filename`` does not match object name
-            ValueError: ``file_proxy_url`` does not look a valid http path
+            ValueError: ``file_proxy_url`` does not look like a valid http(s) path
             NotFoundError: The path could not be resolved to a file (when ``file_proxy_url`` unset)
         """
         if not self.resource:

--- a/stor/settings.py
+++ b/stor/settings.py
@@ -17,7 +17,8 @@ _ENV_VARS = {
         'num_retries': 'OS_NUM_RETRIES'
     },
     'dx': {
-        'auth_token': 'DX_AUTH_TOKEN'
+        'auth_token': 'DX_AUTH_TOKEN',
+        'file_proxy_url': 'DX_FILE_PROXY_URL',
     }
 }
 """

--- a/stor/tests/cassettes_py3/TestTempUrl/test_fail_on_folder.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_fail_on_folder.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"name": "TestTempUrl.test_fail_on_folder.a3ca9318"}'
+    body: '{"name": "TestTempUrl.test_fail_on_folder.8224b93e"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -17,31 +17,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/project/new
   response:
-    body: {string: '{"id":"project-FP9kGvj0y9126vXb405Q2KYP"}'}
+    body:
+      string: '{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:27 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593267723-223783]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671299-127871
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -53,31 +61,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGvj0y9126vXb405Q2KYP/describe
+    uri: https://api.dnanexus.com/project-FjjYbzj0K3gZQ05X3fy1fYfb/describe
   response:
-    body: {string: '{"id":"project-FP9kGvj0y9126vXb405Q2KYP","name":"TestTempUrl.test_fail_on_folder.a3ca9318","class":"project","created":1540593267000,"modified":1540593267000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'}
+    body:
+      string: '{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb","name":"TestTempUrl.test_fail_on_folder.8224b93e","class":"project","created":1580284671000,"modified":1580284671000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['653']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:27 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593267870-763471]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '618'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671406-405280
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"folder": "/temp_folder", "parents": true}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -89,32 +105,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGvj0y9126vXb405Q2KYP/newFolder
+    uri: https://api.dnanexus.com/project-FjjYbzj0K3gZQ05X3fy1fYfb/newFolder
   response:
-    body: {string: '{"id":"project-FP9kGvj0y9126vXb405Q2KYP"}'}
+    body:
+      string: '{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:28 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593268007-42971]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671530-735808
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "folder_file.txt", "folder": "/temp_folder", "project": "project-FP9kGvj0y9126vXb405Q2KYP",
-      "nonce": "b''3bd84d59897cb78d5b918a1894468b51c0b40aaec06a593f43cc91351f5a3ffd''1540593268.083725"}'
+    body: '{"name": "folder_file.txt", "folder": "/temp_folder", "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb",
+      "nonce": "b''da1cdf5abcb18bb48f7841b1394b06fd5b71cc26d9f219608124dfc9f78e2ca4''1580284671.590549"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -126,31 +150,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/file/new
   response:
-    body: {string: '{"id":"file-FP9kGx00y91Gfgvx3zz6pZyv"}'}
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:28 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593268131-624760]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671646-143598
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"fields": {"fileUploadParameters": true}}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -162,31 +194,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGvj0y9126vXb405Q2KYP/describe
+    uri: https://api.dnanexus.com/project-FjjYbzj0K3gZQ05X3fy1fYfb/describe
   response:
-    body: {string: '{"id":"project-FP9kGvj0y9126vXb405Q2KYP","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'}
+    body:
+      string: '{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['205']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:28 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593268275-392924]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671778-982545
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"index": 1, "md5": "8d777f385d3dfec8815d20f7496026dc", "size": 4}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -198,24 +238,32 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGx00y91Gfgvx3zz6pZyv/upload
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/upload
   response:
-    body: {string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/92cd/file/open/file-FP9kGx00y91Gfgvx3zz6pZyv/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223428Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=9390d63312285efdaa20e3db6e17f98cdeb21ee1388b946d14094da24f70f98b","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1540593388422}'}
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/0a10/file/open/file-FjjYbzj0K3gkQQg53bX943xY/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075751Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=b1e59baffc0029574922e6642e5c4c449276505026764e2cba108c1d554257b2","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1580284791901}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['692']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:28 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593268404-685554]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:51 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284671885-208719
+    status:
+      code: 200
+      message: OK
 - request:
     body: data
     headers:
@@ -226,8 +274,7 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
       ? !!binary |
         Y29udGVudC1tZDU=
       : - !!binary |
@@ -241,26 +288,37 @@ interactions:
       : - !!binary |
           QUVTMjU2
     method: PUT
-    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/92cd/file/open/file-FP9kGx00y91Gfgvx3zz6pZyv/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223428Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=9390d63312285efdaa20e3db6e17f98cdeb21ee1388b946d14094da24f70f98b
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/0a10/file/open/file-FjjYbzj0K3gkQQg53bX943xY/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075751Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=b1e59baffc0029574922e6642e5c4c449276505026764e2cba108c1d554257b2
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Content-Length: ['0']
-      Date: ['Fri, 26 Oct 2018 22:34:29 GMT']
-      ETag: ['"8d777f385d3dfec8815d20f7496026dc"']
-      Server: [AmazonS3]
-      x-amz-expiration: ['expiry-date="Sat, 17 Nov 2018 00:00:00 GMT", rule-id="3weekpurge"']
-      x-amz-id-2: [4TW/HHaV5tFc+AlsnhlgfSlXt5TLLVZ1NfQRo5T8SR8/Z/B6OiGOLn+90T9vAVZTRlqoqv3iMUw=]
-      x-amz-request-id: [843C6462AE4D50EF]
-      x-amz-server-side-encryption: [AES256]
-    status: {code: 200, message: OK}
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 29 Jan 2020 07:57:53 GMT
+      ETag:
+      - '"8d777f385d3dfec8815d20f7496026dc"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Thu, 20 Feb 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - hEWgsrpq5BZFqLKTMPuQaxbctoxoukDoMY597zxJOgmGONu66sVNZEbnisz2LejlhQBX2zyTWDA=
+      x-amz-request-id:
+      - EEDB8C092C5B6389
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGvj0y9126vXb405Q2KYP"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -272,31 +330,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGx00y91Gfgvx3zz6pZyv/describe
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/describe
   response:
-    body: {string: '{"id":"file-FP9kGx00y91Gfgvx3zz6pZyv","state":"open"}'}
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY","state":"open"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['53']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:28 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593268981-675095]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:52 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284672491-953500
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -308,31 +374,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGx00y91Gfgvx3zz6pZyv/close
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/close
   response:
-    body: {string: '{"id":"file-FP9kGx00y91Gfgvx3zz6pZyv"}'}
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:29 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593269095-575067]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:52 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284672608-980432
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGvj0y9126vXb405Q2KYP"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -344,31 +418,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGx00y91Gfgvx3zz6pZyv/describe
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/describe
   response:
-    body: {string: '{"id":"file-FP9kGx00y91Gfgvx3zz6pZyv","state":"closing"}'}
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:29 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593269266-63235]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:52 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284672750-578143
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGvj0y9126vXb405Q2KYP"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -380,32 +462,84 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGx00y91Gfgvx3zz6pZyv/describe
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/describe
   response:
-    body: {string: '{"id":"file-FP9kGx00y91Gfgvx3zz6pZyv","state":"closed"}'}
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['55']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:31 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593271391-809360]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:53 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284673865-573052
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "TestTempUrl.test_fail_on_folder.a3ca9318", "level": "VIEW", "limit":
+    body: '{"fields": {"state": true}, "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYbzj0K3gkQQg53bX943xY/describe
+  response:
+    body:
+      string: '{"id":"file-FjjYbzj0K3gkQQg53bX943xY","state":"closed"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:56 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284675989-734501
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_fail_on_folder.8224b93e", "level": "VIEW", "limit":
       2}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -417,32 +551,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/findProjects
   response:
-    body: {string: '{"results":[{"id":"project-FP9kGvj0y9126vXb405Q2KYP","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'}
+    body:
+      string: '{"results":[{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['147']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:31 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593271508-636883]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:56 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284676109-503121
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"objects": [{"name": "temp_folder", "folder": "/", "project": "project-FP9kGvj0y9126vXb405Q2KYP",
+    body: '{"objects": [{"name": "temp_folder", "folder": "/", "project": "project-FjjYbzj0K3gZQ05X3fy1fYfb",
       "batchsize": 2}]}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -454,31 +596,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/resolveDataObjects
   response:
-    body: {string: '{"results":[[]]}'}
+    body:
+      string: '{"results":[[]]}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['16']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:31 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593271648-948342]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '16'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:57:56 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284676275-86757
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -490,22 +640,30 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGvj0y9126vXb405Q2KYP/destroy
+    uri: https://api.dnanexus.com/project-FjjYbzj0K3gZQ05X3fy1fYfb/destroy
   response:
-    body: {string: '{"id":"project-FP9kGvj0y9126vXb405Q2KYP"}'}
+    body:
+      string: '{"id":"project-FjjYbzj0K3gZQ05X3fy1fYfb"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:34 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593271762-271441]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:00 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284676384-340737
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/stor/tests/cassettes_py3/TestTempUrl/test_fail_on_project.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_fail_on_project.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"name": "TestTempUrl.test_fail_on_project.457a40d8"}'
+    body: '{"name": "TestTempUrl.test_fail_on_project.5d0e1027"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -17,31 +17,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/project/new
   response:
-    body: {string: '{"id":"project-FP9kGyj08F6k2JG740JK7GzY"}'}
+    body:
+      string: '{"id":"project-FjjYf200kbXfjfPy3bJ44QYv"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:35 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593275049-688369]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:00 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284680937-102070
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -53,31 +61,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGyj08F6k2JG740JK7GzY/describe
+    uri: https://api.dnanexus.com/project-FjjYf200kbXfjfPy3bJ44QYv/describe
   response:
-    body: {string: '{"id":"project-FP9kGyj08F6k2JG740JK7GzY","name":"TestTempUrl.test_fail_on_project.457a40d8","class":"project","created":1540593275000,"modified":1540593275000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'}
+    body:
+      string: '{"id":"project-FjjYf200kbXfjfPy3bJ44QYv","name":"TestTempUrl.test_fail_on_project.5d0e1027","class":"project","created":1580284680000,"modified":1580284680000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['654']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:35 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593275179-153302]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '619'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:01 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284681052-495641
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -89,22 +105,30 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGyj08F6k2JG740JK7GzY/destroy
+    uri: https://api.dnanexus.com/project-FjjYf200kbXfjfPy3bJ44QYv/destroy
   response:
-    body: {string: '{"id":"project-FP9kGyj08F6k2JG740JK7GzY"}'}
+    body:
+      string: '{"id":"project-FjjYf200kbXfjfPy3bJ44QYv"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:37 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593275301-785494]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:04 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284681169-424241
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/stor/tests/cassettes_py3/TestTempUrl/test_on_file.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_on_file.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"name": "TestTempUrl.test_on_file.ea8879db"}'
+    body: '{"name": "TestTempUrl.test_on_file.7c1ace41"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -17,31 +17,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/project/new
   response:
-    body: {string: '{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ"}'}
+    body:
+      string: '{"id":"project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:37 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593277962-511021]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685269-474860
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -53,31 +61,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGz80Pgfk2JG740JK7GzZ/describe
+    uri: https://api.dnanexus.com/project-FjjYf380PyYYK8Jq3b8V74vk/describe
   response:
-    body: {string: '{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ","name":"TestTempUrl.test_on_file.ea8879db","class":"project","created":1540593277000,"modified":1540593277000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'}
+    body:
+      string: '{"id":"project-FjjYf380PyYYK8Jq3b8V74vk","name":"TestTempUrl.test_on_file.7c1ace41","class":"project","created":1580284685000,"modified":1580284685000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['646']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:38 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593278082-445829]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '611'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685398-485934
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"folder": "/", "parents": true}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -89,32 +105,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGz80Pgfk2JG740JK7GzZ/newFolder
+    uri: https://api.dnanexus.com/project-FjjYf380PyYYK8Jq3b8V74vk/newFolder
   response:
-    body: {string: '{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ"}'}
+    body:
+      string: '{"id":"project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:38 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593278215-403075]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685516-61712
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kGz80Pgfk2JG740JK7GzZ",
-      "nonce": "b''6dc977d27a440eae05f0a648c315ce5ed959d3e4404f6bf5168e5c269f922e53''1540593278.275828"}'
+    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf380PyYYK8Jq3b8V74vk",
+      "nonce": "b''2b298941a5090c3fe6d7622771c3e62f75b10b626ead67db3378597d21086cb8''1580284685.572827"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -126,31 +150,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/file/new
   response:
-    body: {string: '{"id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq"}'}
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:38 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593278326-9076]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685627-729165
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"fields": {"fileUploadParameters": true}}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -162,31 +194,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGz80Pgfk2JG740JK7GzZ/describe
+    uri: https://api.dnanexus.com/project-FjjYf380PyYYK8Jq3b8V74vk/describe
   response:
-    body: {string: '{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'}
+    body:
+      string: '{"id":"project-FjjYf380PyYYK8Jq3b8V74vk","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['205']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:38 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593278537-638906]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685763-63570
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"index": 1, "md5": "8d777f385d3dfec8815d20f7496026dc", "size": 4}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -198,24 +238,32 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/upload
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/upload
   response:
-    body: {string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/02c6/file/open/file-FP9kGzQ0PgfkB0KJ8Bz725xq/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223438Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=953ef8f08b8446434c6ca5ff61d090abe05a5f926fe4b3c171b4898c3ad60413","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1540593398667}'}
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/5223/file/open/file-FjjYf380PyYjYgjJ3fYjyBY0/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075805Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=2dbff5510bee1f43cc5b2d2087f4f8295e823ba058d27223347f9720976384ff","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1580284805892}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['692']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:38 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593278651-319095]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:05 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284685877-692485
+    status:
+      code: 200
+      message: OK
 - request:
     body: data
     headers:
@@ -226,8 +274,7 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
       ? !!binary |
         Y29udGVudC1tZDU=
       : - !!binary |
@@ -241,26 +288,37 @@ interactions:
       : - !!binary |
           QUVTMjU2
     method: PUT
-    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/02c6/file/open/file-FP9kGzQ0PgfkB0KJ8Bz725xq/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223438Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=953ef8f08b8446434c6ca5ff61d090abe05a5f926fe4b3c171b4898c3ad60413
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/5223/file/open/file-FjjYf380PyYjYgjJ3fYjyBY0/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075805Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=2dbff5510bee1f43cc5b2d2087f4f8295e823ba058d27223347f9720976384ff
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Content-Length: ['0']
-      Date: ['Fri, 26 Oct 2018 22:34:40 GMT']
-      ETag: ['"8d777f385d3dfec8815d20f7496026dc"']
-      Server: [AmazonS3]
-      x-amz-expiration: ['expiry-date="Sat, 17 Nov 2018 00:00:00 GMT", rule-id="3weekpurge"']
-      x-amz-id-2: [UGy/hHf4iMR1SoUwk9sGMbHPheiyuD9MrQK57aUZ68GRnBZL9e50dZWpTmXmwpGI5icGl1beC78=]
-      x-amz-request-id: [166DE89CECBF876F]
-      x-amz-server-side-encryption: [AES256]
-    status: {code: 200, message: OK}
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 29 Jan 2020 07:58:07 GMT
+      ETag:
+      - '"8d777f385d3dfec8815d20f7496026dc"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Thu, 20 Feb 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - q/C9j+BKXjqjzKm1SxIC7hoq41MvSuSKMuCJo6wxnsoOWoejls5zSs1z5BOnWcBW4K+6/eYm/bQ=
+      x-amz-request-id:
+      - 41D8EBD5CC1165AB
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGz80Pgfk2JG740JK7GzZ"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -272,31 +330,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/describe
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/describe
   response:
-    body: {string: '{"id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq","state":"open"}'}
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0","state":"open"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['53']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:39 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593279232-383311]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:06 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284686446-819631
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -308,31 +374,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/close
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/close
   response:
-    body: {string: '{"id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq"}'}
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:39 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593279344-391195]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:06 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284686559-732498
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGz80Pgfk2JG740JK7GzZ"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -344,31 +418,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/describe
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/describe
   response:
-    body: {string: '{"id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq","state":"closing"}'}
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:39 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593279477-157467]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:06 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284686679-77204
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kGz80Pgfk2JG740JK7GzZ"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -380,32 +462,84 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/describe
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/describe
   response:
-    body: {string: '{"id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq","state":"closed"}'}
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['55']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:41 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593281603-849397]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:07 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284687792-96200
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "TestTempUrl.test_on_file.ea8879db", "level": "VIEW", "limit":
+    body: '{"fields": {"state": true}, "project": "project-FjjYf380PyYYK8Jq3b8V74vk"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/describe
+  response:
+    body:
+      string: '{"id":"file-FjjYf380PyYjYgjJ3fYjyBY0","state":"closed"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:09 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284689920-349287
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file.7c1ace41", "level": "VIEW", "limit":
       2}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -417,32 +551,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/findProjects
   response:
-    body: {string: '{"results":[{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'}
+    body:
+      string: '{"results":[{"id":"project-FjjYf380PyYYK8Jq3b8V74vk","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['147']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:41 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593281724-153779]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:10 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284690039-593826
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kGz80Pgfk2JG740JK7GzZ",
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf380PyYYK8Jq3b8V74vk",
       "batchsize": 2}]}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -454,31 +596,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/resolveDataObjects
   response:
-    body: {string: '{"results":[[{"project":"project-FP9kGz80Pgfk2JG740JK7GzZ","id":"file-FP9kGzQ0PgfkB0KJ8Bz725xq"}]]}'}
+    body:
+      string: '{"results":[[{"project":"project-FjjYf380PyYYK8Jq3b8V74vk","id":"file-FjjYf380PyYjYgjJ3fYjyBY0"}]]}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['99']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:41 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593281859-768828]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:10 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284690208-123570
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"preauthenticated": true, "duration": 300, "project": "project-FP9kGz80Pgfk2JG740JK7GzZ"}'
+    body: '{"preauthenticated": true, "duration": 300, "filename": "temp_file.txt",
+      "project": "project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -490,31 +641,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kGzQ0PgfkB0KJ8Bz725xq/download
+    uri: https://api.dnanexus.com/file-FjjYf380PyYjYgjJ3fYjyBY0/download
   response:
-    body: {string: '{"url":"https://dl.dnanex.us/F/D/kQj8B8gQk0QFy28Y91Kq5vjz4Ppy48yyZFP0gFBQ","headers":{},"expires":1540593581988}'}
+    body:
+      string: '{"url":"https://dl.dnanex.us/F/D/VGVVF7Vz7p9j2jG1B48BYG9KpY8f33KYg9y6fj16/temp_file.txt","headers":{},"expires":1580284990329}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['112']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:42 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593281981-505930]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:10 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284690323-654822
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -526,22 +685,30 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kGz80Pgfk2JG740JK7GzZ/destroy
+    uri: https://api.dnanexus.com/project-FjjYf380PyYYK8Jq3b8V74vk/destroy
   response:
-    body: {string: '{"id":"project-FP9kGz80Pgfk2JG740JK7GzZ"}'}
+    body:
+      string: '{"id":"project-FjjYf380PyYYK8Jq3b8V74vk"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:44 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593282138-862757]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284690446-959583
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/stor/tests/cassettes_py3/TestTempUrl/test_on_file_canonical.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_on_file_canonical.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"name": "TestTempUrl.test_on_file_canonical.ba432305"}'
+    body: '{"name": "TestTempUrl.test_on_file_canonical.b953494c"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -17,31 +17,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/project/new
   response:
-    body: {string: '{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38"}'}
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:45 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593285497-89739]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284695487-348445
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -53,31 +61,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ180q4Xbvgj6Jkpx4b38/describe
+    uri: https://api.dnanexus.com/project-FjjYf5j03b91Gg2y3bGzZ71p/describe
   response:
-    body: {string: '{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38","name":"TestTempUrl.test_on_file_canonical.ba432305","class":"project","created":1540593285000,"modified":1540593285000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'}
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p","name":"TestTempUrl.test_on_file_canonical.b953494c","class":"project","created":1580284695000,"modified":1580284695000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['656']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:45 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593285688-934495]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '621'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284695605-287320
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"folder": "/", "parents": true}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -89,32 +105,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ180q4Xbvgj6Jkpx4b38/newFolder
+    uri: https://api.dnanexus.com/project-FjjYf5j03b91Gg2y3bGzZ71p/newFolder
   response:
-    body: {string: '{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38"}'}
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:45 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593285839-801617]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284695727-432271
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38",
-      "nonce": "b''23b8694a7cde2b404952ca6c2126087b17281dc00d4a544171872ab89cbd9072''1540593285.903875"}'
+    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf5j03b91Gg2y3bGzZ71p",
+      "nonce": "b''0e766de779918b1e6f1e508ab58382bea94e76764aba64ba444587de02cf47e3''1580284695.785108"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -126,31 +150,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/file/new
   response:
-    body: {string: '{"id":"file-FP9kJ180q4XfzyV6JkV1p4Q6"}'}
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:46 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593285956-570963]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284695834-806631
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"fields": {"fileUploadParameters": true}}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -162,31 +194,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ180q4Xbvgj6Jkpx4b38/describe
+    uri: https://api.dnanexus.com/project-FjjYf5j03b91Gg2y3bGzZ71p/describe
   response:
-    body: {string: '{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'}
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['205']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:46 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593286114-651314]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284695955-659858
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"index": 1, "md5": "8d777f385d3dfec8815d20f7496026dc", "size": 4}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -198,24 +238,32 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/upload
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/upload
   response:
-    body: {string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/6b03/file/open/file-FP9kJ180q4XfzyV6JkV1p4Q6/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223446Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=474c610e27edac6bc39817f4232e67741f6cd24f4d0bbb4044ea2d99769b1c4c","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1540593406258}'}
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/4744/file/open/file-FjjYf5j03b9KyJFx3bgPgF1f/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075816Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=d415a663b9bf145e5d76a6a2860428a158a870ad6f863add8226307f6cff8298","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1580284816075}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['692']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:46 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593286240-275131]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:16 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284696063-501948
+    status:
+      code: 200
+      message: OK
 - request:
     body: data
     headers:
@@ -226,8 +274,7 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
       ? !!binary |
         Y29udGVudC1tZDU=
       : - !!binary |
@@ -241,26 +288,37 @@ interactions:
       : - !!binary |
           QUVTMjU2
     method: PUT
-    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/6b03/file/open/file-FP9kJ180q4XfzyV6JkV1p4Q6/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223446Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=474c610e27edac6bc39817f4232e67741f6cd24f4d0bbb4044ea2d99769b1c4c
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/4744/file/open/file-FjjYf5j03b9KyJFx3bgPgF1f/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075816Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=d415a663b9bf145e5d76a6a2860428a158a870ad6f863add8226307f6cff8298
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Content-Length: ['0']
-      Date: ['Fri, 26 Oct 2018 22:34:47 GMT']
-      ETag: ['"8d777f385d3dfec8815d20f7496026dc"']
-      Server: [AmazonS3]
-      x-amz-expiration: ['expiry-date="Sat, 17 Nov 2018 00:00:00 GMT", rule-id="3weekpurge"']
-      x-amz-id-2: [gTcaImJC/WsoZtf6absWSZ1XYJTawLL8MLTPWiBaCWT+weigKWLb6PB/knVylG5piAiCxLwIOT0=]
-      x-amz-request-id: [ADFD0E6FBBF1DEBF]
-      x-amz-server-side-encryption: [AES256]
-    status: {code: 200, message: OK}
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 29 Jan 2020 07:58:17 GMT
+      ETag:
+      - '"8d777f385d3dfec8815d20f7496026dc"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Thu, 20 Feb 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - X7cWLGsUj54z83hEjIyDE6oEUeP2ni0yIfaVd5yCLGigEUU/Voa3KAAR7nmnly4bzF7/qjIi4GI=
+      x-amz-request-id:
+      - 5F4748F28D5276F1
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -272,31 +330,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/describe
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/describe
   response:
-    body: {string: '{"id":"file-FP9kJ180q4XfzyV6JkV1p4Q6","state":"open"}'}
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f","state":"open"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['53']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:46 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593286809-455654]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:16 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284696724-894555
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -308,31 +374,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/close
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/close
   response:
-    body: {string: '{"id":"file-FP9kJ180q4XfzyV6JkV1p4Q6"}'}
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:46 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593286934-178059]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:16 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284696899-836527
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -344,31 +418,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/describe
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/describe
   response:
-    body: {string: '{"id":"file-FP9kJ180q4XfzyV6JkV1p4Q6","state":"closing"}'}
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:47 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593287086-187684]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284697038-586214
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -380,32 +462,84 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/describe
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/describe
   response:
-    body: {string: '{"id":"file-FP9kJ180q4XfzyV6JkV1p4Q6","state":"closed"}'}
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['55']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:49 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593289218-394625]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284698159-45126
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "TestTempUrl.test_on_file_canonical.ba432305", "level": "VIEW",
+    body: '{"fields": {"state": true}, "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/describe
+  response:
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f","state":"closed"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700283-75539
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_canonical.b953494c", "level": "VIEW",
       "limit": 2}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -417,32 +551,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/findProjects
   response:
-    body: {string: '{"results":[{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'}
+    body:
+      string: '{"results":[{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['147']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:49 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593289346-443522]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700398-826609
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38",
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf5j03b91Gg2y3bGzZ71p",
       "batchsize": 2}]}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -454,67 +596,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/resolveDataObjects
   response:
-    body: {string: '{"results":[[{"project":"project-FP9kJ180q4Xbvgj6Jkpx4b38","id":"file-FP9kJ180q4XfzyV6JkV1p4Q6"}]]}'}
+    body:
+      string: '{"results":[[{"project":"project-FjjYf5j03b91Gg2y3bGzZ71p","id":"file-FjjYf5j03b9KyJFx3bgPgF1f"}]]}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['99']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:49 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593289540-160002]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"preauthenticated": true, "duration": 300, "project": "project-FP9kJ180q4Xbvgj6Jkpx4b38"}'
-    headers:
-      ? !!binary |
-        QXV0aG9yaXphdGlvbg==
-      : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
-      ? !!binary |
-        Q29udGVudC1UeXBl
-      : - !!binary |
-          YXBwbGljYXRpb24vanNvbg==
-      ? !!binary |
-        RE5BbmV4dXMtQVBJ
-      : - !!binary |
-          MS4wLjA=
-      ? !!binary |
-        VXNlci1BZ2VudA==
-      : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
-    method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ180q4XfzyV6JkV1p4Q6/download
-  response:
-    body: {string: '{"url":"https://dl.dnanex.us/F/D/Z1FqyKYjFbpK3kxp6Xgf8y1pXBQK6J0vvKqXV5j3","headers":{},"expires":1540593589718}'}
-    headers:
-      Connection: [keep-alive]
-      Content-Length: ['112']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:49 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593289697-602004]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700572-496649
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -526,22 +640,207 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ180q4Xbvgj6Jkpx4b38/destroy
+    uri: https://api.dnanexus.com/project-FjjYf5j03b91Gg2y3bGzZ71p/describe
   response:
-    body: {string: '{"id":"project-FP9kJ180q4Xbvgj6Jkpx4b38"}'}
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p","name":"TestTempUrl.test_on_file_canonical.b953494c","class":"project","created":1580284695000,"modified":1580284698742,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:52 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593289846-794308]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '659'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700682-857609
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/describe
+  response:
+    body:
+      string: '{"id":"file-FjjYf5j03b9KyJFx3bgPgF1f","project":"project-FjjYf5j03b91Gg2y3bGzZ71p","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1580284695000,"modified":1580284698742,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700803-279726
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"preauthenticated": true, "duration": 300, "filename": "temp_file.txt",
+      "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/download
+  response:
+    body:
+      string: '{"url":"https://dl.dnanex.us/F/D/B3FzV4fY6X8FVX7y6kxjyj0QXX4kbk6kPGY3Yz0K/temp_file.txt","headers":{},"expires":1580285000920}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284700914-372784
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"preauthenticated": true, "duration": 300, "project": "project-FjjYf5j03b91Gg2y3bGzZ71p"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf5j03b9KyJFx3bgPgF1f/download
+  response:
+    body:
+      string: '{"url":"https://dl.dnanex.us/F/D/jb47bZ2qG5xB8K8gfg5Fv54PY8YGBX1pbg2FY4PZ","headers":{},"expires":1580285001041}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:21 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284701035-665650
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-FjjYf5j03b91Gg2y3bGzZ71p/destroy
+  response:
+    body:
+      string: '{"id":"project-FjjYf5j03b91Gg2y3bGzZ71p"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:24 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284701149-720609
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/stor/tests/cassettes_py3/TestTempUrl/test_on_file_named_timed.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_on_file_named_timed.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"name": "TestTempUrl.test_on_file_named_timed.24e2b2bb"}'
+    body: '{"name": "TestTempUrl.test_on_file_named_timed.11fe326e"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -17,31 +17,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/project/new
   response:
-    body: {string: '{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X"}'}
+    body:
+      string: '{"id":"project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:52 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593292874-73647]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:24 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284704957-324297
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -53,31 +61,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ300Jbq68GXkJpbYfb0X/describe
+    uri: https://api.dnanexus.com/project-FjjYf800zq7jxKzZ3b4008y1/describe
   response:
-    body: {string: '{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X","name":"TestTempUrl.test_on_file_named_timed.24e2b2bb","class":"project","created":1540593292000,"modified":1540593292000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-akumar_counsyl"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","archivalState":"live","archivalProgress":null,"totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'}
+    body:
+      string: '{"id":"project-FjjYf800zq7jxKzZ3b4008y1","name":"TestTempUrl.test_on_file_named_timed.11fe326e","class":"project","created":1580284704000,"modified":1580284704000,"billTo":"org-counsyl","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['658']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:53 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593293045-588842]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '623'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:25 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284705080-469522
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"folder": "/", "parents": true}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -89,32 +105,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ300Jbq68GXkJpbYfb0X/newFolder
+    uri: https://api.dnanexus.com/project-FjjYf800zq7jxKzZ3b4008y1/newFolder
   response:
-    body: {string: '{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X"}'}
+    body:
+      string: '{"id":"project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:53 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593293213-574706]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:25 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284705193-742979
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kJ300Jbq68GXkJpbYfb0X",
-      "nonce": "b''b5d4856bfae6dc3472431ba89afff07cf1f6ac2b165c7e3f6c15eefb67189a2f''1540593293.319798"}'
+    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf800zq7jxKzZ3b4008y1",
+      "nonce": "b''843c54ab6fcb0df73700347c17c19692657e02548da46cdb1b08985043a5a970''1580284705.251368"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -126,31 +150,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/file/new
   response:
-    body: {string: '{"id":"file-FP9kJ380JbqPvv365P3k8ZxV"}'}
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:53 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593293374-875725]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:25 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284705300-102995
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"fields": {"fileUploadParameters": true}}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -162,31 +194,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ300Jbq68GXkJpbYfb0X/describe
+    uri: https://api.dnanexus.com/project-FjjYf800zq7jxKzZ3b4008y1/describe
   response:
-    body: {string: '{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'}
+    body:
+      string: '{"id":"project-FjjYf800zq7jxKzZ3b4008y1","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['205']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:53 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593293624-680892]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:25 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284705450-107205
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"index": 1, "md5": "8d777f385d3dfec8815d20f7496026dc", "size": 4}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -198,24 +238,32 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/upload
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/upload
   response:
-    body: {string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/014a/file/open/file-FP9kJ380JbqPvv365P3k8ZxV/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223453Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=fdc7e6feee474ec0a5a37a15df7cd62dd413f34a5ebe67ee3db80c0be477fe0c","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1540593413755}'}
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/9c5d/file/open/file-FjjYf880zq7kk8xz3bKvbZxf/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075825Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=b28c0a952f0c9f682ce98f76288d693be1f41a0e2ea4970fded8641d898b402c","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1580284825577}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['692']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:53 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593293741-192318]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:25 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284705563-852635
+    status:
+      code: 200
+      message: OK
 - request:
     body: data
     headers:
@@ -226,8 +274,7 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
       ? !!binary |
         Y29udGVudC1tZDU=
       : - !!binary |
@@ -241,26 +288,37 @@ interactions:
       : - !!binary |
           QUVTMjU2
     method: PUT
-    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/014a/file/open/file-FP9kJ380JbqPvv365P3k8ZxV/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20181026%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181026T223453Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=fdc7e6feee474ec0a5a37a15df7cd62dd413f34a5ebe67ee3db80c0be477fe0c
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/9c5d/file/open/file-FjjYf880zq7kk8xz3bKvbZxf/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200129T075825Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=b28c0a952f0c9f682ce98f76288d693be1f41a0e2ea4970fded8641d898b402c
   response:
-    body: {string: ''}
+    body:
+      string: ''
     headers:
-      Content-Length: ['0']
-      Date: ['Fri, 26 Oct 2018 22:34:55 GMT']
-      ETag: ['"8d777f385d3dfec8815d20f7496026dc"']
-      Server: [AmazonS3]
-      x-amz-expiration: ['expiry-date="Sat, 17 Nov 2018 00:00:00 GMT", rule-id="3weekpurge"']
-      x-amz-id-2: [HuyNrpLXGPX7PtZpYCjXRknDvBtjVIlcCekzEEIua85mZYIGpCqd6Ez4WKpSXj2wy3OdXoXuRUg=]
-      x-amz-request-id: [3E1C4087D8E4961D]
-      x-amz-server-side-encryption: [AES256]
-    status: {code: 200, message: OK}
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 29 Jan 2020 07:58:27 GMT
+      ETag:
+      - '"8d777f385d3dfec8815d20f7496026dc"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Thu, 20 Feb 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - xMTMb2HwmCmd+voiYSdGuPstcWxc9FinrHIZTiJj4QdXkbsHwTa9lRFGR640G/CYxPCxQzVpwRk=
+      x-amz-request-id:
+      - 923D1D7DB671E37E
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ300Jbq68GXkJpbYfb0X"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -272,31 +330,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/describe
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/describe
   response:
-    body: {string: '{"id":"file-FP9kJ380JbqPvv365P3k8ZxV","state":"open"}'}
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf","state":"open"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['53']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:54 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593294325-127904]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:26 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284706143-12617
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -308,31 +374,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/close
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/close
   response:
-    body: {string: '{"id":"file-FP9kJ380JbqPvv365P3k8ZxV"}'}
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['38']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:54 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593294448-462051]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:26 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284706251-191110
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ300Jbq68GXkJpbYfb0X"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -344,31 +418,39 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/describe
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/describe
   response:
-    body: {string: '{"id":"file-FP9kJ380JbqPvv365P3k8ZxV","state":"closing"}'}
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:54 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593294589-286120]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:26 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284706376-959439
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fields": {"state": true}, "project": "project-FP9kJ300Jbq68GXkJpbYfb0X"}'
+    body: '{"fields": {"state": true}, "project": "project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -380,32 +462,84 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/describe
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/describe
   response:
-    body: {string: '{"id":"file-FP9kJ380JbqPvv365P3k8ZxV","state":"closed"}'}
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf","state":"closing"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['55']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:56 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593296718-879344]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:27 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284707499-802943
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"name": "TestTempUrl.test_on_file_named_timed.24e2b2bb", "level": "VIEW",
+    body: '{"fields": {"state": true}, "project": "project-FjjYf800zq7jxKzZ3b4008y1"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/describe
+  response:
+    body:
+      string: '{"id":"file-FjjYf880zq7kk8xz3bKvbZxf","state":"closed"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:29 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284709670-752473
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_named_timed.11fe326e", "level": "VIEW",
       "limit": 2}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -417,32 +551,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/findProjects
   response:
-    body: {string: '{"results":[{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X","level":"ADMINISTER","permissionSources":["user-akumar_counsyl"],"public":false}],"next":null}'}
+    body:
+      string: '{"results":[{"id":"project-FjjYf800zq7jxKzZ3b4008y1","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['147']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:56 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593296845-408731]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:29 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284709779-651495
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FP9kJ300Jbq68GXkJpbYfb0X",
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-FjjYf800zq7jxKzZ3b4008y1",
       "batchsize": 2}]}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -454,32 +596,40 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
     uri: https://api.dnanexus.com/system/resolveDataObjects
   response:
-    body: {string: '{"results":[[{"project":"project-FP9kJ300Jbq68GXkJpbYfb0X","id":"file-FP9kJ380JbqPvv365P3k8ZxV"}]]}'}
+    body:
+      string: '{"results":[[{"project":"project-FjjYf800zq7jxKzZ3b4008y1","id":"file-FjjYf880zq7kk8xz3bKvbZxf"}]]}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['99']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:57 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593297054-942383]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:29 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284709928-623866
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"preauthenticated": true, "duration": 1, "filename": "random.txt", "project":
-      "project-FP9kJ300Jbq68GXkJpbYfb0X"}'
+      "project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -491,70 +641,108 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/file-FP9kJ380JbqPvv365P3k8ZxV/download
+    uri: https://api.dnanexus.com/file-FjjYf880zq7kk8xz3bKvbZxf/download
   response:
-    body: {string: '{"url":"https://dl.dnanex.us/F/D/p2ZFFXP0fFVG8Zjz29pzJZXkZzk9kxyyKkY61pBP/random.txt","headers":{},"expires":1540593298191}'}
+    body:
+      string: '{"url":"https://dl.dnanex.us/F/D/pV2qpZG014z5yf9QBgYqj9Fq8xj3Q4ZV929yVXZQ/random.txt","headers":{},"expires":1580284711041}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['123']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:34:57 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593297176-659985]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:30 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284710036-57264
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dl.dnanex.us]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
     method: GET
-    uri: https://dl.dnanex.us/F/D/p2ZFFXP0fFVG8Zjz29pzJZXkZzk9kxyyKkY61pBP/random.txt
+    uri: https://dl.dnanex.us/F/D/pV2qpZG014z5yf9QBgYqj9Fq8xj3Q4ZV929yVXZQ/random.txt
   response:
-    body: {string: data}
+    body:
+      string: data
     headers:
-      Accept-Ranges: [bytes]
-      Access-Control-Allow-Credentials: ['true']
-      Cache-Control: ['private, max-age=31536000']
-      Connection: [close]
-      Content-Length: ['4']
-      Content-Type: [text/plain]
-      Date: ['Fri, 26 Oct 2018 22:34:57 GMT']
-      Last-Modified: ['Fri, 26 Oct 2018 22:34:55 GMT']
-      content-disposition: [attachment; filename="random.txt"]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - private, max-age=31536000
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4'
+      Content-Type:
+      - text/plain
+      Date:
+      - Wed, 29 Jan 2020 07:58:30 GMT
+      Last-Modified:
+      - Wed, 29 Jan 2020 07:58:29 GMT
+      content-disposition:
+      - attachment; filename="random.txt"
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Connection: [close]
-      Host: [dl.dnanex.us]
-      User-Agent: [Python-urllib/3.6]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
     method: GET
-    uri: https://dl.dnanex.us/F/D/p2ZFFXP0fFVG8Zjz29pzJZXkZzk9kxyyKkY61pBP/random.txt
+    uri: https://dl.dnanex.us/F/D/pV2qpZG014z5yf9QBgYqj9Fq8xj3Q4ZV929yVXZQ/random.txt
   response:
-    body: {string: '{"error":{"type":"InvalidAuthentication","message":"The supplied
-        authentication token has expired"}}'}
+    body:
+      string: '{"error":{"type":"InvalidAuthentication","message":"The supplied authentication
+        token has expired"}}'
     headers:
-      Connection: [close]
-      Content-Length: ['100']
-      Content-Type: [application/octet-stream]
-      Date: ['Fri, 26 Oct 2018 22:35:00 GMT']
-      Server: [nginx/1.8.0]
-    status: {code: 401, message: Unauthorized}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Wed, 29 Jan 2020 07:58:33 GMT
+      Server:
+      - nginx/1.14.0
+    status:
+      code: 401
+      message: Unauthorized
 - request:
     body: '{}'
     headers:
       ? !!binary |
         QXV0aG9yaXphdGlvbg==
       : - !!binary |
-          YmVhcmVyIHh2aWtXSmY1RWZ5b0ZLN3RzNThLZzAxTTIzZWZsT0Fx
+          QmVhcmVyIGlqWUNiMjRMZ3V1ZTNBNnV5QTRwRXdPYXh4VFNYUWt1
       ? !!binary |
         Q29udGVudC1UeXBl
       : - !!binary |
@@ -566,22 +754,30 @@ interactions:
       ? !!binary |
         VXNlci1BZ2VudA==
       : - !!binary |
-          ZHhweS8wLjI2NS4wLTgwLWc0YjYwMTY4NyAoRGFyd2luLTE4LjAuMC14ODZfNjQtaTM4Ni02NGJp
-          dCk=
+          ZHhweS8wLjI4OS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
     method: POST
-    uri: https://api.dnanexus.com/project-FP9kJ300Jbq68GXkJpbYfb0X/destroy
+    uri: https://api.dnanexus.com/project-FjjYf800zq7jxKzZ3b4008y1/destroy
   response:
-    body: {string: '{"id":"project-FP9kJ300Jbq68GXkJpbYfb0X"}'}
+    body:
+      string: '{"id":"project-FjjYf800zq7jxKzZ3b4008y1"}'
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['41']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 26 Oct 2018 22:35:03 GMT']
-      Server: [nginx]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [Express]
-      X-Request-ID: [1540593300473-426117]
-      X-Upgrade-Info: ['A recommended update (v0.266.1) is available for your client/SDK.
-          You can download it from https://wiki.dnanexus.com/Downloads#Install']
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2020 07:58:37 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1580284713149-788267
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/stor/tests/cassettes_py3/TestTempUrl/test_on_file_with_proxy_url.yaml
+++ b/stor/tests/cassettes_py3/TestTempUrl/test_on_file_with_proxy_url.yaml
@@ -1,0 +1,1645 @@
+interactions:
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:14 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151794713-467957
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151794000,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '626'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:14 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151794840-251028
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"folder": "/", "parents": true}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/newFolder
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151795005-238953
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "nonce": "b''f098020a81831b29469ad136fb7494e8159931ddfbe91b9fb84d5ed030041eb0''1586151795.068892"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file/new
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151795124-792694
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"fileUploadParameters": true}}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151795267-735975
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"index": 1, "md5": "8d777f385d3dfec8815d20f7496026dc", "size": 4}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/upload
+  response:
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/3504/file/open/file-Fp5G2vj0XZkyYg5KGffkvZ7g/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200406%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200406T054315Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=ec5e75d69849ce8f5cbefc917c2b39c60b7df363a08454ae184408a48d34b165","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"jXd/OF09/siBXSD3SWAm3A==","content-length":"4"},"expires":1586151915393}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151795377-34148
+    status:
+      code: 200
+      message: OK
+- request:
+    body: data
+    headers:
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+      ? !!binary |
+        Y29udGVudC1tZDU=
+      : - !!binary |
+          alhkL09GMDkvc2lCWFNEM1NXQW0zQT09
+      ? !!binary |
+        Y29udGVudC10eXBl
+      : - !!binary |
+          YmluYXJ5L29jdGV0LXN0cmVhbQ==
+      ? !!binary |
+        eC1hbXotc2VydmVyLXNpZGUtZW5jcnlwdGlvbg==
+      : - !!binary |
+          QUVTMjU2
+    method: PUT
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/3504/file/open/file-Fp5G2vj0XZkyYg5KGffkvZ7g/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200406%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200406T054315Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=ec5e75d69849ce8f5cbefc917c2b39c60b7df363a08454ae184408a48d34b165
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 06 Apr 2020 05:43:16 GMT
+      ETag:
+      - '"8d777f385d3dfec8815d20f7496026dc"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Tue, 28 Apr 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - B1Lfkbec5UGf1hHfw/XyRGRag1IIKRBJiD03VWfXyOc9IHmqriXUVImrqmbtWQnlyS704kn/W9I=
+      x-amz-request-id:
+      - 9DB6A3F799841FA8
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"state": true}, "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","state":"open"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '53'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:15 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151795963-424034
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/close
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:16 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151796071-110979
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"state": true}, "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","state":"closing"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:16 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151796203-6714
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"state": true}, "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","state":"closed"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797320-673951
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866", "level": "VIEW",
+      "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797434-539256
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[{"project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797595-149921
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797699-878781
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1586151795000,"modified":1586151796567,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797832-411961
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:17 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151797942-723034
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866", "level": "VIEW",
+      "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798064-866427
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[{"project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798232-78195
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798337-780051
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1586151795000,"modified":1586151796567,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798458-421131
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798569-140443
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866", "level": "VIEW",
+      "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798692-624341
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[{"project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798870-326801
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:18 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151798973-375825
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1586151795000,"modified":1586151796567,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799092-808052
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799207-700689
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866", "level": "VIEW",
+      "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799335-207501
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[{"project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799500-783131
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799603-786210
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1586151795000,"modified":1586151796567,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799721-371301
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:19 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799827-569244
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestTempUrl.test_on_file_with_proxy_url.1209f866", "level": "VIEW",
+      "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151799980-844021
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file.txt", "folder": "/", "project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[{"project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g"}]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151800148-31398
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151800256-77328
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5G2vj0XZkyYg5KGffkvZ7g/describe
+  response:
+    body:
+      string: '{"id":"file-Fp5G2vj0XZkyYg5KGffkvZ7g","project":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","class":"file","sponsored":false,"name":"temp_file.txt","types":[],"state":"closed","hidden":false,"links":[],"folder":"/","tags":[],"created":1586151795000,"modified":1586151796567,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"media":"text/plain","archivalState":"live","size":4}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151800374-685972
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ","name":"TestTempUrl.test_on_file_with_proxy_url.1209f866","class":"project","created":1586151794000,"modified":1586151796567,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":3.725290298461914e-9,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":8.19563865661621e-11,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:20 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151800487-153756
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5G2vQ0XZkZKxgk3jKzV8xQ/destroy
+  response:
+    body:
+      string: '{"id":"project-Fp5G2vQ0XZkZKxgk3jKzV8xQ"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 05:43:23 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586151800609-25963
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -135,7 +135,8 @@ class TestCliBasics(BaseCliTest):
             },
             'dx': {
                 'auth_token': 'fake_token',
-                'wait_on_close': 0
+                'wait_on_close': 0,
+                'file_proxy_url': ''
             }
         }
         filename = os.path.join(os.path.dirname(__file__), 'file_data', 'test.cfg')

--- a/stor/tests/test_settings.py
+++ b/stor/tests/test_settings.py
@@ -78,7 +78,8 @@ class TestSettings(unittest.TestCase):
             },
             'dx': {
                 'auth_token': '',
-                'wait_on_close': 0
+                'wait_on_close': 0,
+                'file_proxy_url': '',
             }
         }
         settings._initialize()
@@ -133,7 +134,8 @@ class TestSettings(unittest.TestCase):
             },
             'dx': {
                 'auth_token': 'fake_token',
-                'wait_on_close': 0
+                'wait_on_close': 0,
+                'file_proxy_url': '',
             }
         }
         filename = os.path.join(os.path.dirname(__file__), 'file_data', 'test.cfg')


### PR DESCRIPTION


  Added ``DX_FILE_PROXY_URL`` and ``[dx] -> file_proxy_url`` setting to allow for constructing
  DNAnexus paths with a custom gateway.  You might want this to be able to construct valid bam
  paths for samtools or IGV!

  Really intersted in your own file proxy gateway? Email support@dnanexus.com to request it! ;)
  Also, you're encouraged to hit up the Bioinformatics Software Engineering team at Myriad to ask
  about the potential to share gateway code.

  Generally, usage will look like::

    $ stor url dx://proj:/folder/mypath.csv
    https://dl.dnanex.us/F/D/awe1323/mypath.csv
    $ export DX_FILE_PROXY_URL=https://my-dnax-proxy.example.com/gateway
    $ stor url dx://proj:/folder/mypath.csv
    https://my-dnax-proxy.example.com/gateway/proj/folder/mypath.csv

* Now ``temp_url()`` always sets filename to virtual object name when creating temp urls, matching the docstring.
  To get the old (buggy!) behavior, pass ``filename=''`` to ``temp_url()``

---

TODOs:

- [ ] regenerate the cassettes for temp URLs
