### PR TITLE
Add a `stor completions` command to generate tab completion text

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,10 +34,10 @@ After this, you will need to edit your ~/.bashrc or ~/.bash_profile to include t
         . $(brew --prefix)/etc/bash_completion
     fi
 
-The final step is to then copy stor's tab completion script in the proper location::
+The final step is to then dump stor's tab completion script in the proper location::
 
     mkdir `brew --prefix`/etc/bash_completion.d
-    cp `which stor-completion.bash` `brew --prefix`/etc/bash_completion.d/stor
+    stor completions >  `brew --prefix`/etc/bash_completion.d/stor
 
 Linux
 ~~~~~
@@ -50,8 +50,8 @@ It can be installed using apt-get or yum::
 
 The bash completion script for stor can then be installed with::
 
-    cp `which stor-completion.bash` /etc/bash_completion.d/stor
+    stor completions > /etc/bash_completion.d/stor
 
 If you don't have permissions to install the script to /etc, it can also be saved in your home directory as follows::
 
-    cat `which stor-completion.bash` >> ~/.bash_completion
+    stor completions >> ~/.bash_completion

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,22 @@
 Release Notes
 =============
 
+v4.0
+----
+
+API Breaks
+^^^^^^^^^^
+
+* ``stor-completions.bash`` is no longer on the path (see :ref:`installation instructions <cli_tab_completion_installation>`
+  for more detail).
+
+API Additons
+^^^^^^^^^^^^
+
+* Tab completions are now available via the ``stor completions`` command.
+  Use it to dump completions to appropriate location (see :ref:`installation instructions <cli_tab_completion_installation>`
+  for more detail).
+
 v3.2.0
 ------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ show_missing = 1
 
 [files]
 packages = stor
-scripts = stor/stor-completion.bash
 
 [entry_points]
 console_scripts =

--- a/stor/cli.py
+++ b/stor/cli.py
@@ -96,7 +96,8 @@ from stor import Path
 from stor import utils
 from stor.extensions import swiftstack
 
-PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url', 'convert-swiftstack')
+PRINT_CMDS = ('list', 'listdir', 'ls', 'cat', 'pwd', 'walkfiles', 'url', 'convert-swiftstack',
+              'completions')
 SERVICES = ('s3', 'swift', 'dx')
 
 ENV_FILE = os.path.expanduser('~/.stor-cli.env')
@@ -303,6 +304,11 @@ def _convert_swiftstack(path, bucket=None):
         raise ValueError("invalid path for conversion: '%s'" % path)
 
 
+def _completions(**kwargs):
+    with (stor.Path(__file__).parent / 'stor-completion.bash').open('r') as fp:
+        return fp.read()
+
+
 def create_parser():
     parser = argparse.ArgumentParser(description='A command line interface for stor.')
 
@@ -426,6 +432,12 @@ def create_parser():
     parser_swiftstack.add_argument('path')
     parser_swiftstack.add_argument('--bucket', default=None)
     parser_swiftstack.set_defaults(func=_convert_swiftstack)
+
+    parser_completions = subparsers.add_parser(
+        'completions',
+        help='emit bash completions script to stdout'
+    )
+    parser_completions.set_defaults(func=_completions)
 
     return parser
 

--- a/stor/tests/test_cli.py
+++ b/stor/tests/test_cli.py
@@ -646,3 +646,9 @@ class TestCd(BaseCliTest):
     def test_pwd_error(self):
         with self.assertOutputMatches(exit_status=1, stderr='invalid service'):
             self.parse_args('stor pwd service')
+
+class TestCompletions(BaseCliTest):
+    def test_completion(self):
+        self.parse_args('stor completions')
+        assert '_stor_complete' in sys.stdout.getvalue()
+        assert '_get_comp_words_by_ref' in sys.stdout.getvalue()


### PR DESCRIPTION
@pkaleta - in prep for switching to poetry as build tool (which makes it easier to do github actions anyways)

`poetry` does not support bash scripts in its `scripts` section. So
instead we add a `stor completions` command to dump to stdout (which
accomplishes essentially same purpose as previous)