### PR TITLE
Error earlier when open() called on DXProject to fix uncaught exception in `__del__ `

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,15 +31,6 @@ jobs:
         poetry config --local virtualenvs.in-project true
     - name: Install venv
       run: make venv
-    - name: List versions - pip
-      run: |
-        mkdir htmlcov
-        poetry run pip list | tee htmlcov/pip-freeze.txt
-    - name: "List versions: pytest and python"
-      run: |
-        set -x
-        python --version | tee htmlcov/python.txt
-        pytest --version | tee htmlcov/pytest.txt
     - name: Test with coverage
       run: make unit-test
     - name: Lint
@@ -49,7 +40,6 @@ jobs:
     - name: Build coverage report
       if: always()
       run: |
-        cp .coverage htmlcov/.coverage
         poetry run python -m coverage html
     - name: Create coverage report artifact
       uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Build coverage report
       if: always()
       run: |
+        cp .coverage htmlcov/.coverage
         poetry run python -m coverage html
     - name: Create coverage report artifact
       uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         mkdir htmlcov
         poetry run pip list | tee htmlcov/pip-freeze.txt
-    - name: List versions: pytest and python
+    - name: "List versions: pytest and python"
       run: |
         set -x
         python --version | tee htmlcov/python.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         set -x
         python --version | tee htmlcov/python.txt
-        pytest --version | tee htmlcov/pytest.txt
+        poetry run pytest --version | tee htmlcov/pytest.txt
     - name: Test with coverage
       run: make unit-test
     - name: Lint

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,7 +34,7 @@ jobs:
     - name: List versions - pip
       run: |
         mkdir htmlcov
-        poetry run pip list | tee htmlcov/pip-freeze.txt
+        poetry run pip list | tee htmlcov/pip-list.txt
     - name: "List versions: pytest and python"
       run: |
         set -x

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,15 @@ jobs:
         poetry config --local virtualenvs.in-project true
     - name: Install venv
       run: make venv
+    - name: List versions - pip
+      run: |
+        mkdir htmlcov
+        poetry run pip list | tee htmlcov/pip-freeze.txt
+    - name: List versions: pytest and python
+      run: |
+        set -x
+        python --version | tee htmlcov/python.txt
+        pytest --version | tee htmlcov/pytest.txt
     - name: Test with coverage
       run: make unit-test
     - name: Lint

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -35,6 +35,8 @@ Bug Fixes
   ``OBSFile`` objects would throw an exception in ``__del__`` method.
 * Only call ``OBSFile._wait_on_close()`` when we actually wrote data AND we
   were in write mode.
+* Eliminate exception in ``__del__`` method when calling ``stor.open`` on a DNAnexus project path.
+* ``stor.open()`` now throws an error earlier when incorrectly calling ``open()`` on a DNAnexus project path.
 
 Developer Changes
 ^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ exclude_lines = [
     "pragma: no cover",
     "raise NotImplementedError",
 ]
-fail_under = 100
+fail_under = 99.92
 show_missing = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ exclude_lines = [
     "pragma: no cover",
     "raise NotImplementedError",
 ]
-fail_under = 99.92
+fail_under = 100
 show_missing = true
 
 [build-system]

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -848,6 +848,34 @@ class DXPath(OBSPath):
             suo = OBSUploadObject(fp.name, object_name='/' + self.resource)
             return self.upload([suo], **kwargs)
 
+    def open(self, mode='r', encoding=None):
+        """
+        Opens a OBSFile that can be read or written to and is uploaded to
+        the remote service.
+
+        For examples of reading and writing opened objects, view
+        OBSFile.
+
+        Args:
+            mode (str): The mode of object IO. Currently supports reading
+                ("r" or "rb") and writing ("w", "wb")
+            encoding (str): text encoding to use. Defaults to
+                ``locale.getpreferredencoding(False)``
+
+        Returns:
+            OBSFile: The file object for Swift/S3/DX.
+
+        Raises:
+            ValueError: if attempting to write to project
+            DNAnexusError: A dxpy client error occured.
+        """
+        if encoding and encoding not in ('utf-8', 'utf8'):
+            raise ValueError('For DNAnexus paths, encoding is always assumed to be '
+                             'utf-8. Please switch your encoding')
+        if not self.resource:
+            raise ValueError("Can only read or write on file paths not project paths")
+        return super().open(mode=mode, encoding=encoding)
+
     def list(self,
              canonicalize=False,
              starts_with=None,

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -166,10 +166,6 @@ class OBSPath(Path):
             DNAnexusError: A dxpy client error occured.
             RemoteError: A s3 client error occurred.
         """
-        if encoding and encoding not in ('utf-8', 'utf8') \
-                and isinstance(self, stor.dx.DXPath):  # pragma: no cover
-            raise ValueError('For DNAnexus paths, encoding is always assumed to be '
-                             'utf-8. Please switch your encoding')
         return OBSFile(self, mode=mode, encoding=encoding)
 
     def list(self):

--- a/stor/tests/cassettes_py3/TestOpen/test_valid_and_invalid_encoding_for_dnanexus.yaml
+++ b/stor/tests/cassettes_py3/TestOpen/test_valid_and_invalid_encoding_for_dnanexus.yaml
@@ -1,0 +1,494 @@
+interactions:
+- request:
+    body: '{"name": "TestOpen.test_valid_and_invalid_encoding_for_dnanexus.d1f314c4"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project/new
+  response:
+    body:
+      string: '{"id":"project-Fp5v0b00z533XQ5p7ggb6F12"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:44 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217044451-766918
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5v0b00z533XQ5p7ggb6F12/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5v0b00z533XQ5p7ggb6F12","name":"TestOpen.test_valid_and_invalid_encoding_for_dnanexus.d1f314c4","class":"project","created":1586217044000,"modified":1586217044000,"billTo":"org-mwh_rnd","level":"ADMINISTER","dataUsage":0,"sponsoredDataUsage":0,"region":"aws:us-east-1","summary":"","description":"","protected":false,"restricted":false,"downloadRestricted":false,"containsPHI":false,"createdBy":{"user":"user-jeffrey.tratner_myriad.com"},"version":0,"storageCost":0,"pendingTransfer":null,"tags":[],"defaultInstanceType":"mem2_hdd2_x2","totalSponsoredEgressBytes":0,"consumedSponsoredEgressBytes":0,"atSpendingLimit":false}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '640'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:44 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217044564-734526
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "TestOpen.test_valid_and_invalid_encoding_for_dnanexus.d1f314c4",
+      "level": "VIEW", "limit": 2}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/findProjects
+  response:
+    body:
+      string: '{"results":[{"id":"project-Fp5v0b00z533XQ5p7ggb6F12","level":"ADMINISTER","permissionSources":["user-jeffrey.tratner_myriad.com"],"public":false}],"next":null}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:44 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217044679-311187
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file", "folder": "/", "project": "project-Fp5v0b00z533XQ5p7ggb6F12",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '16'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:44 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217044830-947401
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"objects": [{"name": "temp_file", "folder": "/", "project": "project-Fp5v0b00z533XQ5p7ggb6F12",
+      "batchsize": 2}]}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/system/resolveDataObjects
+  response:
+    body:
+      string: '{"results":[[]]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '16'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:44 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217044928-725840
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"project": "project-Fp5v0b00z533XQ5p7ggb6F12", "folder": "/", "parents":
+      true, "name": "temp_file", "nonce": "b''3702c11653b3c6abaf4277f1800e511c46b95e98c1ac0e6c20726bc95d0b7a42''1586217044.982960"}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file/new
+  response:
+    body:
+      string: '{"id":"file-Fp5v0b80z539JzJ29Fg9yKgv"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:45 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217045030-430097
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"fileUploadParameters": true}}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5v0b00z533XQ5p7ggb6F12/describe
+  response:
+    body:
+      string: '{"id":"project-Fp5v0b00z533XQ5p7ggb6F12","fileUploadParameters":{"maximumPartSize":5368709120,"minimumPartSize":5242880,"maximumFileSize":5497558138880,"maximumNumParts":10000,"emptyLastPartAllowed":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:45 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217045172-526454
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"index": 1, "md5": "1cb251ec0d568de6a929b520c4aed8d1", "size": 4}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5v0b80z539JzJ29Fg9yKgv/upload
+  response:
+    body:
+      string: '{"url":"https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/171f/file/open/file-Fp5v0b80z539JzJ29Fg9yKgv/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200406%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200406T235045Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=0b4146e89fbae7d76b70067a73757ceb15319ecb9a1ed33a521a42305bee99eb","headers":{"host":"dnanexus-platform-upload-prod.s3.amazonaws.com","content-type":"binary/octet-stream","x-amz-server-side-encryption":"AES256","content-md5":"HLJR7A1WjeapKbUgxK7Y0Q==","content-length":"4"},"expires":1586217165324}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:45 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217045313-380374
+    status:
+      code: 200
+      message: OK
+- request:
+    body: text
+    headers:
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+      ? !!binary |
+        Y29udGVudC1tZDU=
+      : - !!binary |
+          SExKUjdBMVdqZWFwS2JVZ3hLN1kwUT09
+      ? !!binary |
+        Y29udGVudC10eXBl
+      : - !!binary |
+          YmluYXJ5L29jdGV0LXN0cmVhbQ==
+      ? !!binary |
+        eC1hbXotc2VydmVyLXNpZGUtZW5jcnlwdGlvbg==
+      : - !!binary |
+          QUVTMjU2
+    method: PUT
+    uri: https://dnanexus-platform-upload-prod.s3.amazonaws.com/filev2/171f/file/open/file-Fp5v0b80z539JzJ29Fg9yKgv/1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJDCC37XBLBSWJBVQ%2F20200406%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200406T235045Z&X-Amz-Expires=120&X-Amz-SignedHeaders=content-length%3Bcontent-md5%3Bcontent-type%3Bhost%3Bx-amz-server-side-encryption&X-Amz-Signature=0b4146e89fbae7d76b70067a73757ceb15319ecb9a1ed33a521a42305bee99eb
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 06 Apr 2020 23:50:46 GMT
+      ETag:
+      - '"1cb251ec0d568de6a929b520c4aed8d1"'
+      Server:
+      - AmazonS3
+      x-amz-expiration:
+      - expiry-date="Tue, 28 Apr 2020 00:00:00 GMT", rule-id="3weekpurge"
+      x-amz-id-2:
+      - Oas6hqS0RGA3WpZpBYdWAhfLquWTdFhHJHPHUBWtlZFH6Ptw5ZomNSXJ5Ai40ENspDjjUJ1aEFY=
+      x-amz-request-id:
+      - 3E35B58FEAEC25C9
+      x-amz-server-side-encryption:
+      - AES256
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/file-Fp5v0b80z539JzJ29Fg9yKgv/close
+  response:
+    body:
+      string: '{"id":"file-Fp5v0b80z539JzJ29Fg9yKgv"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:45 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217045910-538175
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      ? !!binary |
+        QXV0aG9yaXphdGlvbg==
+      : - !!binary |
+          QmVhcmVyIGFoR3NUQk9pZ3FtZlV6dThqTUJLUFFQVFFrUmhTYVJ1
+      ? !!binary |
+        Q29udGVudC1UeXBl
+      : - !!binary |
+          YXBwbGljYXRpb24vanNvbg==
+      ? !!binary |
+        RE5BbmV4dXMtQVBJ
+      : - !!binary |
+          MS4wLjA=
+      ? !!binary |
+        VXNlci1BZ2VudA==
+      : - !!binary |
+          ZHhweS8wLjI5MS4xIChEYXJ3aW4tMTcuNy4wLXg4Nl82NC1pMzg2LTY0Yml0KQ==
+    method: POST
+    uri: https://api.dnanexus.com/project-Fp5v0b00z533XQ5p7ggb6F12/destroy
+  response:
+    body:
+      string: '{"id":"project-Fp5v0b00z533XQ5p7ggb6F12"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Apr 2020 23:50:50 GMT
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Express
+      X-Request-ID:
+      - 1586217046027-969354
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -301,8 +301,7 @@ line4
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)
         with pytest.raises(ValueError, match='Can only.*file paths not project paths'):
-            with dx_p.open(mode='wb') as f:
-                f.write(b'data')
+            fp = dx_p.open(mode='wb')
         with pytest.raises(ValueError, match='Cannot write to project'):
             dx_p.write_object(b'data')
 

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -324,6 +324,14 @@ line4
                 obj.write(b'hello world')
         self.assertEqual(dx_p.open().read(), 'hello world')
 
+    def test_valid_and_invalid_encoding_for_dnanexus(self):
+        self.setup_temporary_project()
+        dx_p = DXPath('dx://' + self.project + ':/temp_file')
+        with pytest.raises(ValueError, match='encoding is always assumed to be utf-8'):
+            dx_p.open(encoding="ascii")
+        with dx_p.open('w', encoding="utf-8") as fp:
+            fp.write('text')
+
 
 class TestDXOBSFile(SharedOBSFileCases, unittest.TestCase):
     drive = 'dx://project:'  # project is required for DX paths

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -301,7 +301,7 @@ line4
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)
         with pytest.raises(ValueError, match='Can only.*file paths not project paths'):
-            fp = dx_p.open(mode='wb')
+            dx_p.open(mode='wb')
         with pytest.raises(ValueError, match='Cannot write to project'):
             dx_p.write_object(b'data')
 

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -292,15 +292,19 @@ line4
         with pytest.raises(exceptions.NotFoundError, match='No data object'):
             dx_p.open().read()
         dx_p = DXPath('dx://' + self.project)
-        with pytest.raises(ValueError, match='not a project'):
+        with pytest.raises(ValueError, match='Can only.*file paths not project paths'):
             dx_p.open().read()
+        with pytest.raises(ValueError, match='not a project'):
+            dx_p.read_object()
 
     def test_write_to_project_fail(self):
         self.setup_temporary_project()
         dx_p = DXPath('dx://' + self.project)
-        with pytest.raises(ValueError, match='Cannot write to project'):
+        with pytest.raises(ValueError, match='Can only.*file paths not project paths'):
             with dx_p.open(mode='wb') as f:
                 f.write(b'data')
+        with pytest.raises(ValueError, match='Cannot write to project'):
+            dx_p.write_object(b'data')
 
     def test_write_w_settings_no_timeout(self):
         self.setup_temporary_project()


### PR DESCRIPTION
Raise an exception directly in `stor.open` if we have a project path.

Previously, we were raising an exception at `write_object`;
however, if you actually attempted to write data to the path, this would
result in an exception in the `__del__` method as `stor` tried to flush
data.

This also helps reduce noise from the test suite (i.e., those test annotations)

Documented changes:

* Eliminate exception in ``__del__`` method when calling ``stor.open`` on a DNAnexus project path.
* ``stor.open()`` now throws an error earlier when incorrectly calling ``open()`` on a DNAnexus project path.