### PR TITLE
Fix version generation and tag creation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ endif
 
 # Distribution
 
-VERSION=$(shell $(WITH_PBR) python setup.py --version | sed 's/\([0-9]*\.[0-9]*\.[0-9]*\).*$$/\1/')
+VERSION=$(shell poetry version | cut -d' ' -f2)
 
 .PHONY: tag
 tag: ##[distribution] Tag the release.
-tag: venv
+tag:
 	echo "Tagging version as ${VERSION}"
 	git tag -a ${VERSION} -m "Version ${VERSION}"
 	# We won't push changes or tags here allowing the pipeline to do that, so we don't accidentally do that locally.


### PR DESCRIPTION
@jtratner 

With this in place, we get:

```
➜  stor (fix-tagging) ✗ make version
4.0.0
```

and

```
➜  stor (master) ✗ make tag
echo "Tagging version as 4.0.0"
Tagging version as 4.0.0
git tag -a 4.0.0 -m "Version 4.0.0"
# We won't push changes or tags here allowing the pipeline to do that, so we don't accidentally do that locally.
```