### PR TITLE
Add trailing slash to file_proxy_url if absent.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,12 +1,17 @@
 Release Notes
 =============
 
+v4.0.1
+------
+
+* Add trailing slash to file_proxy_url if absent, to fix a bug with generating temp URLs.
+
 v4.0 - Python 3 + Poetry!
 -------------------------
 
 Only Python 3.6+ is supported - Python 2.7 and Python 3.5 support is dropped!
 
-Note: the major version bump is because we've dropped 2.7 support, aside from that 
+Note: the major version bump is because we've dropped 2.7 support, aside from that
 this would be a feature level change.
 
 Now stor installs via ``poetry`` (this should be transparent to users).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stor"
-version = "4.0.0"
+version = "4.0.1"
 description = "Cross-compatible API for accessing Posix and OBS storage systems"
 authors = ["Counsyl Inc. <opensource@counsyl.com>"]
 license = "MIT"

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -191,7 +191,7 @@ class DXPath(OBSPath):
             >>> stor.Path('dx://proj:/folder/mypath.csv').temp_url()
             'https://dl.dnanex.us/F/D/awe1323/mypath.csv'
             >>> with stor.settings.use({'dx': {'file_proxy_url':
-            ...     'https://my-dnax-proxy.example.com/gateway'}):
+            ...     'https://my-dnax-proxy.example.com/gateway'}}):
             ... stor.Path('dx://proj:/folder/mypath.csv').temp_url()
             'https://my-dnax-proxy.example.com/gateway/proj/folder/mypath.csv'
 

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -221,6 +221,9 @@ class DXPath(OBSPath):
                 raise ValueError(
                     'filename MUST match object name when file_proxy_url is set'
                 )
+            # Append trailing slash, so that full proxy URL is included in the generated URL.
+            if not file_proxy_url.endswith("/"):
+                file_proxy_url += "/"
             return urllib.parse.urljoin(
                 file_proxy_url,
                 f'{self.virtual_project}/{self.virtual_resource}'

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -1005,6 +1005,8 @@ class TestTempUrl(DXTestCase):
                 with pytest.raises(ValueError, match='filename MUST match object name'):
                     dx_p.temp_url(filename='another_name.txt')
 
+            assert proxy_path in dx_p.temp_url()
+
     def test_on_file_with_proxy_url(self):
         self.setup_temporary_project()
         self.setup_file('/temp_file.txt')


### PR DESCRIPTION
@jtratner 

Right now, [this example from the docs](https://counsyl.github.io/stor/dx.html#stor.dx.DXPath.temp_url) doesn't work, because proxy URL doesn't have a trailing slash and therefore the `gateway` part is stripped off of the generated URL:



```
In [3]: with stor.settings.use({'dx': {'file_proxy_url': 'https://my-dnax-proxy.example.com/gateway'}}): 
   ...:     print(stor.Path('dx://proj:/folder/mypath.csv').temp_url()) 
   ...:                          
https://my-dnax-proxy.example.com/proj/folder/mypath.csv
```

It does work however, if you add a trailing slash to the proxy URL:

```
In [2]: with stor.settings.use({'dx': {'file_proxy_url': 'https://my-dnax-proxy.example.com/gateway/'}}): 
   ...:     print(stor.Path('dx://proj:/folder/mypath.csv').temp_url()) 
   ...:                                                                                                                                                                                                                                
https://my-dnax-proxy.example.com/gateway/proj/folder/mypath.csv
```

This PR adds a trailing slash to the `file_proxy_url` if it's missing. I've also added test that replicates the issue and proves that this fix works.