### PR TITLE
add read mode for dxpy

### DIFF
--- a/stor/dx.py
+++ b/stor/dx.py
@@ -848,6 +848,7 @@ class DXPath(OBSPath):
 
     def read_object(self, mode='r'):
         """Reads an individual object from DX.
+        Note dxpy for Py3 automatically decodes the DXFile.read using utf-8.
 
         Returns:
             bytes: the raw bytes from the object on DX.
@@ -859,6 +860,8 @@ class DXPath(OBSPath):
                                    mode=mode)
         with _wrap_dx_calls():
             result = file_handler.read()
+        # TODO (akumar): allow other encoding after update of encoding in dxpy for Py3
+        result = result.encode('utf-8')  # dxpy for py3 already decodes the data with 'utf-8'
         return result
 
     def write_object(self, content, **kwargs):

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -846,7 +846,7 @@ class DXPath(OBSPath):
                     'Source path ({}) does not exist. Please provide a valid source'
                     .format(upload_obj.source))
 
-    def read_object(self):
+    def read_object(self, mode='r'):
         """Reads an individual object from DX.
         Note dxpy for Py3 automatically decodes the DXFile.read using utf-8.
 
@@ -856,7 +856,8 @@ class DXPath(OBSPath):
         if not self.resource:
             raise ValueError('Can only read_object() on a file path, not a project')
         file_handler = dxpy.DXFile(dxid=self.canonical_resource,
-                                   project=self.canonical_project)
+                                   project=self.canonical_project,
+                                   mode=mode)
         with _wrap_dx_calls():
             result = file_handler.read()
         # TODO (akumar): allow other encoding after update of encoding in dxpy for Py3

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -848,7 +848,7 @@ class DXPath(OBSPath):
 
     def read_object(self, mode='r'):
         """Reads an individual object from DX.
-        Note dxpy for Py3 automatically decodes the DXFile.read using utf-8.
+        Note dxpy for Py3 automatically decodes the DXFile.read using utf-8 if str.
 
         Returns:
             bytes: the raw bytes from the object on DX.
@@ -860,8 +860,8 @@ class DXPath(OBSPath):
                                    mode=mode)
         with _wrap_dx_calls():
             result = file_handler.read()
-        # TODO (akumar): allow other encoding after update of encoding in dxpy for Py3
-        result = result.encode('utf-8')  # dxpy for py3 already decodes the data with 'utf-8'
+        if mode == 'r':
+            result = result.encode('utf-8')  # dxpy for py3 already decodes the data with 'utf-8'
         return result
 
     def write_object(self, content, **kwargs):

--- a/stor/dx.py
+++ b/stor/dx.py
@@ -848,7 +848,6 @@ class DXPath(OBSPath):
 
     def read_object(self, mode='r'):
         """Reads an individual object from DX.
-        Note dxpy for Py3 automatically decodes the DXFile.read using utf-8.
 
         Returns:
             bytes: the raw bytes from the object on DX.
@@ -860,8 +859,6 @@ class DXPath(OBSPath):
                                    mode=mode)
         with _wrap_dx_calls():
             result = file_handler.read()
-        # TODO (akumar): allow other encoding after update of encoding in dxpy for Py3
-        result = result.encode('utf-8')  # dxpy for py3 already decodes the data with 'utf-8'
         return result
 
     def write_object(self, content, **kwargs):

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -128,7 +128,7 @@ class OBSPath(Path):
         normed = posixpath.normpath('/' + str(self)[len(self.drive):])[1:]
         return self.path_class(self.drive + normed)
 
-    def read_object(self):
+    def read_object(self, mode='r'):
         """Reads an individual object from OBS.
 
         Returns:
@@ -413,7 +413,7 @@ class OBSFile(object):
         if self.mode == 'r':
             buf = self.stream_cls(self._path.read_object().decode(self.encoding))
         elif self.mode == 'rb':
-            buf = self.stream_cls(self._path.read_object())
+            buf = self.stream_cls(self._path.read_object(mode='rb'))
         elif self.mode in ('w', 'wb'):
             buf = self.stream_cls()
         else:

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -471,7 +471,7 @@ class S3Path(OBSPath):
         """Get content type for path (using ContentType field from Boto) or empty string."""
         return self.stat().get('ContentType', '')
 
-    def read_object(self):
+    def read_object(self, mode=None):
         """Read an individual object from OBS.
 
         Returns:

--- a/stor/swift.py
+++ b/stor/swift.py
@@ -577,7 +577,7 @@ class SwiftPath(OBSPath):
 
     @_swift_retry(exceptions=(NotFoundError, UnavailableError,
                               InconsistentDownloadError, UnauthorizedError))
-    def read_object(self):
+    def read_object(self, mode=None):
         """Reads an individual object from OBS.
 
         Returns:


### PR DESCRIPTION
Now that [dxpy](https://github.com/dnanexus/dx-toolkit/issues/426) supports non-utf8 read modes, pass 'rb' through

`make lint` doesn't work tho:

```
Warning, treated as error:
failed to reach any of the inventories with the following issues:
intersphinx inventory 'http://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPConnectionPool(host='docs.python.org', port=80): Max retries exceeded with url: /3/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x107478d50>: Failed to establish a new connection: [Errno 60] Operation timed out'))
```