### PR TITLE
More verbose error msg.

### DIFF
--- a/stor/s3.py
+++ b/stor/s3.py
@@ -744,7 +744,8 @@ class S3Path(OBSPath):
                 pool.join()
 
         if uploaded['failed']:
-            raise exceptions.FailedUploadError('an error occurred while uploading', uploaded)
+            raise exceptions.FailedUploadError(
+                'an error occurred while uploading, info={info}'.format(info=uploaded))
 
         utils.check_condition(condition, [r['dest'] for r in uploaded['completed']])
         return uploaded


### PR DESCRIPTION
@jtratner 

Now the error is:

```
FailedUploadError: an error occurred while uploading, info={'completed': [], 'failed': [{'source': 'AUTHORS', 'dest': S3Path("s3://counsyl-roi/AUTHORS"), 'success': False, 'error': FailedUploadError('Failed to upload AUTHORS to counsyl-roi/AUTHORS: An error occurred (ExpiredToken) when calling the PutObject operation: The provided token has expired.')}]}
```

as opposed to:

```
FailedUploadError: an error occurred while uploading
```