### PR TITLE
Support mixed canonical paths

### DIFF
--- a/stor/dx.py
+++ b/stor/dx.py
@@ -1210,6 +1210,8 @@ class DXVirtualPath(DXPath):
         if utils.has_trailing_slash(self):
             raise ValueError('Invalid operation ({method}) on folder path ({path})'
                              .format(path=self, method=sys._getframe(2).f_code.co_name))
+        if utils.is_valid_dxid(self.resource, "file"):
+            return self.resource
         objects = [{
             'name': self.name,
             'folder': ('/' + self.resource).parent,

--- a/stor/tests/test_dx.py
+++ b/stor/tests/test_dx.py
@@ -1960,3 +1960,17 @@ class TestContentType(DXTestCase):
         self.assertEqual(DXPath('dx://P:/C/T').content_type, 'text/plain')
         mock_stat.return_value = {}
         self.assertEqual(DXPath('dx://P:/C/T').content_type, '')
+
+
+class TestMixedPaths(DXTestCase):
+    def test_mixed_paths(self):
+        self.setup_temporary_project()
+        pth = stor.Path(f"dx://{self.project}:/mypath.txt")
+        with pth.open("w") as fp:
+            fp.write("sometext")
+        file_id = pth.canonical_path.name
+        project_id = pth.canonical_path.project
+
+        assert stor.Path(f"dx://{project_id}:/{pth.name}").canonical_path == pth.canonical_path
+        assert stor.Path(f"dx://{project_id}:/{file_id}").canonical_path == pth.canonical_path
+        assert stor.Path(f"dx://{pth.project}:/{file_id}").canonical_path == pth.canonical_path


### PR DESCRIPTION
Currently when you try to use a path like `dx://someproj:file-123`, you get an error about data not found:

```
NotFoundError: No data object was found for the given path (dx://myproj:file-G0GYf0Q0BqQ4kbBfJvGgFG4K) on DNAnexus
```

This just fixes it to check if valid dxid and then returns it.