### PR TITLE
Update stor upload, download to work on AWS lambda for python3.8 runtime

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,10 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 v4.1.0
 ------
 * Replace ``multiprocessing.ThreadPool`` with ``concurrent.futures.ThreadPoolExecutor``
- to support using stor on AWS Lambda with a Python 3.8 runtime.
+  to support using stor on AWS Lambda with a Python 3.8 runtime.
 
 v4.0.2
 ------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v4.1.0
+------
+* Replace ``multiprocessing.ThreadPool`` with ``concurrent.futures.ThreadPoolExecutor``
+ to support using stor on AWS Lambda with a Python 3.8 runtime.
+
 v4.0.2
 ------
 * fix DeprecationWarning (#140)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stor"
-version = "4.0.2"
+version = "4.1.0"
 description = "Cross-compatible API for accessing Posix and OBS storage systems"
 authors = ["Counsyl Inc. <opensource@counsyl.com>"]
 license = "MIT"

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -3,7 +3,7 @@ An experimental implementation of S3 in stor
 """
 from functools import partial
 import logging
-from multiprocessing.pool import ThreadPool
+from concurrent.futures import as_completed, ThreadPoolExecutor
 import os
 import tempfile
 import threading
@@ -580,25 +580,18 @@ class S3Path(OBSPath):
 
         downloaded = {'completed': [], 'failed': []}
         with S3DownloadLogger(len(files_to_download)) as dl:
-            pool = ThreadPool(options['object_threads'])
-            try:
-                result_iter = pool.imap_unordered(download_w_config, files_to_download)
-                while True:
-                    try:
-                        result = result_iter.next(0xFFFF)
-                        if result['success']:
-                            dl.add_result(result)
-                            downloaded['completed'].append(result)
-                        else:
-                            downloaded['failed'].append(result)
-                    except StopIteration:
-                        break
-                pool.close()
-            except BaseException:
-                pool.terminate()
-                raise
-            finally:
-                pool.join()
+            with ThreadPoolExecutor(max_workers=options.get("object_threads")) as executor:
+                futures = {
+                    executor.submit(download_w_config, file_to_download): file_to_download
+                    for file_to_download in files_to_download
+                }
+                for fut in as_completed(futures):
+                    result = fut.result()
+                    if result["success"]:
+                        dl.add_result(result)
+                        downloaded['completed'].append(result)
+                    else:
+                        downloaded['failed'].append(result)
 
         if downloaded['failed']:
             raise exceptions.FailedDownloadError('an error occurred while downloading', downloaded)
@@ -723,25 +716,18 @@ class S3Path(OBSPath):
 
         uploaded = {'completed': [], 'failed': []}
         with S3UploadLogger(len(files_to_upload)) as ul:
-            pool = ThreadPool(options['object_threads'])
-            try:
-                result_iter = pool.imap_unordered(upload_w_config, files_to_upload)
-                while True:
-                    try:
-                        result = result_iter.next(0xFFFF)
-                        if result['success']:
-                            ul.add_result(result)
-                            uploaded['completed'].append(result)
-                        else:
-                            uploaded['failed'].append(result)
-                    except StopIteration:
-                        break
-                pool.close()
-            except BaseException:
-                pool.terminate()
-                raise
-            finally:
-                pool.join()
+            with ThreadPoolExecutor(max_workers=options.get("object_threads")) as executor:
+                futures = {
+                    executor.submit(upload_w_config, file_to_upload): file_to_upload
+                    for file_to_upload in files_to_upload
+                }
+                for fut in as_completed(futures):
+                    result = fut.result()
+                    if result["success"]:
+                        ul.add_result(result)
+                        uploaded['completed'].append(result)
+                    else:
+                        uploaded['failed'].append(result)
 
         if uploaded['failed']:
             raise exceptions.FailedUploadError(

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -589,9 +589,9 @@ class S3Path(OBSPath):
                     result = fut.result()
                     if result["success"]:
                         dl.add_result(result)
-                        downloaded['completed'].append(result)
+                        downloaded["completed"].append(result)
                     else:
-                        downloaded['failed'].append(result)
+                        downloaded["failed"].append(result)
 
         if downloaded['failed']:
             raise exceptions.FailedDownloadError('an error occurred while downloading', downloaded)
@@ -725,9 +725,9 @@ class S3Path(OBSPath):
                     result = fut.result()
                     if result["success"]:
                         ul.add_result(result)
-                        uploaded['completed'].append(result)
+                        uploaded["completed"].append(result)
                     else:
-                        uploaded['failed'].append(result)
+                        uploaded["failed"].append(result)
 
         if uploaded['failed']:
             raise exceptions.FailedUploadError(

--- a/stor/s3.py
+++ b/stor/s3.py
@@ -586,13 +586,12 @@ class S3Path(OBSPath):
                     for file_to_download in files_to_download
                 }
                 for fut in as_completed(futures.keys()):
-                    source, dest = futures[fut]
                     try:
                         result = fut.result()
                     except Exception as e:
                         raise exceptions.FailedDownloadError(
                             "An exception occured while attempting to download file "
-                            f"{futures[fut][source]}: {e}"
+                            f'{futures[fut]["source"]}: {e}'
                         )
 
                     if result["success"]:

--- a/stor/test.py
+++ b/stor/test.py
@@ -355,7 +355,11 @@ class DXTestCase(DXTestMixin, unittest.TestCase):
 class MockFuture():
     """A class to minimally mock methods for Future objects in ThreadPoolExecutor."""
     def __init__(self, **kwargs):
-        self.__result = {"success": "complete", "dest": kwargs.get("dest"), "source": kwargs.get("source")}
+        self.__result = {
+            "success": "complete",
+            "dest": kwargs.get("dest"),
+            "source": kwargs.get("source")
+        }
 
     def result(self):
         return self.__result

--- a/stor/test.py
+++ b/stor/test.py
@@ -1,13 +1,12 @@
 import inspect
-import unittest
 import os
 import sys
+import unittest
+from unittest import mock
 import uuid
 
 import dxpy
 import vcr
-
-from unittest import mock
 
 from stor import Path
 from stor import s3
@@ -263,6 +262,10 @@ class S3TestCase(unittest.TestCase, S3TestMixin):
             del s3._thread_local.s3_transfer_config
         except AttributeError:
             pass
+
+    def tearDown(self):
+        super(S3TestCase, self).tearDown()
+        self.doCleanups()
 
 
 class DXTestCase(DXTestMixin, unittest.TestCase):

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1340,7 +1340,7 @@ class TestDownload(S3TestCase):
             S3Path('s3://bucket/my/obj2'),
             S3Path('s3://bucket/my/obj3')
         ]
-        self.mock_s3_transfer.download_file.side_effect = [None, ValueError]
+        self.mock_s3_transfer.download_file.side_effect = ValueError
 
         with self.assertRaises(ValueError):
             S3Path('s3://bucket/path').download('test')

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1,5 +1,4 @@
-from concurrent.futures._base import FINISHED, Future
-from concurrent.futures.thread import _WorkItem
+from concurrent.futures.thread import _base
 import datetime
 import ntpath
 from tempfile import NamedTemporaryFile
@@ -1088,12 +1087,12 @@ class TestUpload(S3TestCase):
                                               use_manifest=True)
 
     @mock.patch.object(
-        Future,
+        _base.Future,
         "result",
         autospec=True,
         return_value={"success": "complete", "dest": 10, "source": 90}
     )
-    @mock.patch("stor.s3.as_completed", return_value=[Future() for x in range(0, 20)])
+    @mock.patch("stor.s3.as_completed", return_value=[_base.Future() for x in range(0, 20)])
     @mock.patch("stor.s3.ThreadPoolExecutor", autospec=True)
     def test_upload_object_threads(
         self, mock_pool, mock_completed, mock_future, mock_getsize, mock_files
@@ -1287,12 +1286,12 @@ class TestDownload(S3TestCase):
 
     @mock.patch.object(S3Path, 'list', autospec=True)
     @mock.patch.object(
-        Future,
+        _base.Future,
         "result",
         autospec=True,
         return_value={"success": "complete", "dest": 10, "source": 90}
     )
-    @mock.patch("stor.s3.as_completed", return_value=[Future() for x in range(0, 20)])
+    @mock.patch("stor.s3.as_completed", return_value=[_base.Future() for x in range(0, 20)])
     @mock.patch("stor.s3.ThreadPoolExecutor", autospec=True)
     def test_download_object_threads(
         self, mock_pool, mock_completed, mock_future, mock_list, mock_getsize, mock_make_dest_dir

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -1,4 +1,3 @@
-from concurrent.futures.thread import _WorkItem
 import datetime
 import ntpath
 from tempfile import NamedTemporaryFile

--- a/stor/tests/test_s3.py
+++ b/stor/tests/test_s3.py
@@ -18,7 +18,7 @@ from stor import Path
 from stor import settings
 from stor import s3
 from stor.s3 import S3Path
-from stor.test import MockExecutor, MockFuture, S3TestCase
+from stor.test import MockExecutor, S3TestCase
 from stor.tests.shared_obs import SharedOBSFileCases
 from stor import utils
 
@@ -1085,7 +1085,11 @@ class TestUpload(S3TestCase):
             S3Path('s3://bucket/path').upload(['file'],
                                               use_manifest=True)
 
-    @mock.patch("stor.s3.as_completed", autospec=True, side_effect=lambda futures: [fut for fut in futures])
+    @mock.patch(
+        "stor.s3.as_completed",
+        autospec=True,
+        side_effect=lambda futures: [fut for fut in futures]
+    )
     @mock.patch("stor.s3.ThreadPoolExecutor", autospec=True, return_value=MockExecutor())
     def test_upload_object_threads(
         self, mock_pool, mock_completed, mock_getsize, mock_files
@@ -1292,7 +1296,11 @@ class TestDownload(S3TestCase):
         self.assertEquals(self.mock_s3_transfer.download_file.call_count, 3)
 
     @mock.patch.object(S3Path, 'list', autospec=True)
-    @mock.patch("stor.s3.as_completed", autospec=True, side_effect=lambda futures: [fut for fut in futures])
+    @mock.patch(
+        "stor.s3.as_completed",
+        autospec=True,
+        side_effect=lambda futures: [fut for fut in futures]
+    )
     @mock.patch("stor.s3.ThreadPoolExecutor", autospec=True, return_value=MockExecutor())
     def test_download_object_threads(
         self, mock_pool, mock_completed, mock_list, mock_getsize, mock_make_dest_dir
@@ -1316,7 +1324,10 @@ class TestDownload(S3TestCase):
         assert len(mock_completed_called_with_futures) == 20
         assert all(
             [
-                fut.result()["dest"] == ["test"] and fut.result()["source"] == f"s3://bucket/file{idx}"
+                (
+                    fut.result()["dest"] == ["test"] and
+                    fut.result()["source"] == f"s3://bucket/file{idx}"
+                )
                 for idx, fut in enumerate(mock_completed_called_with_futures)
             ]
         )


### PR DESCRIPTION
### Description

AWS lambda cannot use `multiprocessing.Pool` and `multiprocessing.Queue` as of python3.8, due to the use of `SemLock` (see [this blog post from AWS](https://aws.amazon.com/blogs/compute/parallel-processing-in-python-with-aws-lambda/)). In order to use `stor` on AWS lambda with a python3.8 runtime, we will replace use of `multiprocessing.ThreadPool` with `concurrent.futures.ThreadPoolExecutor`, which does not use SemLock.

### Changes
 - Updated `ThreadPool` to `ThreadPoolExecutor` in `stor/s3.py` for both `upload` and `download`.
 - Updated related unit tests for upload and download.
   - Added `MockFuture` and `MockExecutor` for mocking `ThreadPoolExecutor`.
   - Added `tearDown()` method to `test.py::S3TestCase` to prevent mock teardown/cleanup bleed. 
 - Updated `test_upload_other_error` to appropriately raise `FailedUploadError` with `ThreadPoolExecutor` changes.
 - Updated `test_download_other_error` to appropriately raise `FailedDownloadError` with `ThreadPoolExecutor` changes.

### Testing
 - Successful execution of updated tests:
    - `test_upload_object_threads`
    - `test_upload_other_error`
    - `test_download_object_threads`
    - `test_download_other_error`
- Successful execution of CI testing on all three python versions. 

### Todo
- [x] Update version prior to merge.
- [x] Any necessary docstring updates for s3.py `upload` and `download`.