### PR TITLE
Fix tests by removing deprecated python 3.6 from test matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.12]  # NOTE: 3.6 no longer supported
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.12]  # NOTE: 3.6 no longer supported
+        python-version: [3.7, 3.8, 3.9]  # NOTE: 3.6 no longer supported
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As it says in description, replace python 3.6 with 3.9, now that 3.6 is no longer available as a simple built-in environment on github actions.

Sadly 3.12 seemed to have an issue with installing here, so saving that for a future improvement :(