### PR TITLE
Move swift and dxpy into extras

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        POETRY_EXTRAS: ["-E swift -E dxpy", ""]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +31,9 @@ jobs:
         pip install poetry==${{env.POETRY_VERSION}}
         poetry config --local virtualenvs.in-project true
     - name: Install venv
-      run: make venv
+      run: |
+        export POETRY_EXTRAS=${{matrix.POETRY_EXTRAS}}
+        make venv
     - name: List versions - pip
       run: |
         mkdir htmlcov

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        POETRY_EXTRAS: ["-E swift -E dxpy", ""]
+        POETRY_EXTRAS: ["-E swift", "-E dxpy", "", "-E swift -E dxpy"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WITH_PBR=$(WITH_VENV) PBR_REQUIREMENTS_FILES=requirements-pbr.txt
 venv: $(VENV_ACTIVATE)
 
 $(VENV_ACTIVATE): poetry.lock
-	poetry install
+	poetry install $(POETRY_EXTRAS)
 	touch $@
 
 develop: venv

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v4.0.3
+------
+* Guard dxpy imports in utils so you can use stor without dxpy installed.
+
+
 v4.0.2
 ------
 * fix DeprecationWarning (#140)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stor"
-version = "4.0.2"
+version = "4.0.3"
 description = "Cross-compatible API for accessing Posix and OBS storage systems"
 authors = ["Counsyl Inc. <opensource@counsyl.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,11 @@ requests = ">=2.20.0"
 boto3 = ">=1.7.0"
 cached-property = ">=1.5.1"
 dxpy = ">=0.278.0"
-python-keystoneclient = ">=1.8.1"
-python-swiftclient = ">=3.6.0"
+python-keystoneclient = {version = ">=1.8.1", optional = true}
+python-swiftclient = {version = ">=3.6.0", optional = true}
+
+[tool.poetry.extras]
+swift = ["python-keystoneclient", "python-swiftclient"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,13 @@ python = "^3.6"
 requests = ">=2.20.0"
 boto3 = ">=1.7.0"
 cached-property = ">=1.5.1"
-dxpy = ">=0.278.0"
+dxpy = {version = ">=0.278.0", optional = true }
 python-keystoneclient = {version = ">=1.8.1", optional = true}
 python-swiftclient = {version = ">=3.6.0", optional = true}
 
 [tool.poetry.extras]
 swift = ["python-keystoneclient", "python-swiftclient"]
+dxpy = ["dxpy"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"

--- a/stor/obs.py
+++ b/stor/obs.py
@@ -26,7 +26,7 @@ def _delegate_to_buffer(attr_name, valid_modes=None):
 
 try:
     from swiftclient.service import SwiftUploadObject
-except ImportError:
+except ImportError:  # pragma: no cover
     class SwiftUploadObject(object):
         """Give 90% of the utility of SwiftUploadObject class without swiftclient!"""
         def __init__(self, source, object_name=None, options=None):

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -8,9 +8,6 @@ import shutil
 from subprocess import check_call
 import tempfile
 
-from dxpy.bindings import verify_string_dxid
-from dxpy.exceptions import DXError
-
 from stor import exceptions
 
 logger = logging.getLogger(__name__)
@@ -257,6 +254,9 @@ def is_valid_dxid(dxid, expected_classes):
     Returns
         bool: Whether given dxid is a valid path of one of expected_classes
     """
+    from dxpy.bindings import verify_string_dxid
+    from dxpy.exceptions import DXError
+
     try:
         return verify_string_dxid(dxid, expected_classes) is None
     except DXError:

--- a/stor/utils.py
+++ b/stor/utils.py
@@ -187,8 +187,7 @@ def is_swift_path(p):
     Returns:
         bool: True if p is a Swift path, False otherwise.
     """
-    from stor.swift import SwiftPath
-    return p.startswith(SwiftPath.drive)
+    return p.startswith('swift://')
 
 
 def is_filesystem_path(p):
@@ -214,8 +213,7 @@ def is_s3_path(p):
     Returns
         bool: True if p is a S3 path, False otherwise.
     """
-    from stor.s3 import S3Path
-    return p.startswith(S3Path.drive)
+    return p.startswith('s3://')
 
 
 def is_obs_path(p):
@@ -241,8 +239,7 @@ def is_dx_path(p):
     Returns
         bool: True if p is a DX path, False otherwise.
     """
-    from stor.dx import DXPath
-    return p.startswith(DXPath.drive)
+    return p.startswith('dx://')
 
 
 def is_valid_dxid(dxid, expected_classes):


### PR DESCRIPTION
Follow-on to #143 . Makes swift and dxpy actually optional so people can opt into complex dependencies rather than being forced to use 'em, yay!