### PR TITLE
[BIOINFSW-6193] Replace pkg_resources use with importlib metadata

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,45 +14,56 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-poetry-${{ matrix.python-version }}-
+
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip
         pip install poetry==${{env.POETRY_VERSION}}
         poetry config --local virtualenvs.in-project true
+
     - name: Install venv
       run: make venv
+
     - name: List versions - pip
       run: |
         mkdir htmlcov
         poetry run pip list | tee htmlcov/pip-list.txt
+
     - name: "List versions: pytest and python"
       run: |
         set -x
         python --version | tee htmlcov/python.txt
         poetry run pytest --version | tee htmlcov/pytest.txt
+
     - name: Test with coverage
       run: make unit-test
+
     - name: Lint
       run: make lint
+
     - name: Doc build
       run: make docs
+
     - name: Build coverage report
       if: always()
       run: |
         cp .coverage htmlcov/.coverage
         poetry run python -m coverage html
+
     - name: Create coverage report artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       # TODO: make this only run if the build step at least ran
       if: always()
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,10 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]  # NOTE: 3.6 no longer supported
+        python-version: [3.8]  # TODO: deprecate python <3.10 and run tests on 3.10, 3.11, 3.12...
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]  # NOTE: 3.6 no longer supported

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -68,6 +68,6 @@ jobs:
       if: always()
       with:
         # Artifact name
-        name: html-coverage
+        name: html-coverage-${{ matrix.python-version }}
         # Directory containing files to upload
         path: ./htmlcov

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,10 +7,10 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # TODO: update to ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]  # TODO: deprecate python <3.10 and run tests on 3.10, 3.11, 3.12...
+        python-version: [3.7, 3.8]  # TODO: deprecate python <3.10 and run tests on 3.10, 3.11, 3.12...
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,12 +13,12 @@ jobs:
         python-version: [3.7, 3.8, 3.9]  # NOTE: 3.6 no longer supported
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]  # NOTE: 3.6 no longer supported

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 build/*
 docs/_build/*
 dist/*
+.idea
+.vscode
+full_test_results
+atm4j_results
 
 *.log
 nosetests*.xml

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v4.1.1
+------
+* Fix ``UserWarning`` for deprecation of ``pkg_resources``
+* Fall back to ``importlib_metadata`` or `pkg_resources``, whichever is available, to get version info for python <3.8
+
 v4.1.0
 ------
 * Replace ``multiprocessing.ThreadPool`` with ``concurrent.futures.ThreadPoolExecutor``

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 v4.1.1
 ------
 * Fix ``UserWarning`` for deprecation of ``pkg_resources``
-* Fall back to ``importlib_metadata`` or `pkg_resources``, whichever is available, to get version info for python <3.8
+* Fall back to ``importlib_metadata`` or ``pkg_resources``, whichever is available, to get version info for python <3.8
 
 v4.1.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stor"
-version = "4.1.0"
+version = "4.1.1"
 description = "Cross-compatible API for accessing Posix and OBS storage systems"
 authors = ["Counsyl Inc. <opensource@counsyl.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ stor = "stor.cli:main"
 branch = true
 source = ["stor"]
 omit = [
+    "*__init__.py",
     "stor/tests/test_posix_path_compat.py",
     "stor/tests/test_integration_swift.py",
     "stor/tests/test_integration_s3.py",

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -20,7 +20,15 @@ functions.
 
 See `stor.swift` for more information on Swift-specific functionality.
 """
-from importlib import metadata
+try:
+    from importlib import metadata
+except ImportError:  # Python < 3.8
+    try:
+        import importlib_metadata as metadata
+    except ImportError:
+        # Fall back to pkg_resources for Python < 3.8 if importlib_metadata not available
+        import pkg_resources
+        metadata = None
 
 from stor.utils import copy
 from stor.utils import copytree
@@ -32,10 +40,12 @@ from stor.base import Path
 from stor import settings
 
 
-# TODO: Compile this - costs ~700us to do this on import
 try:
-    __version__ = metadata.version("stor")
-except metadata.PackageNotFoundError:  # pragma: no cover
+    if metadata is not None:
+        __version__ = metadata.version("stor")
+    else:
+        __version__ = pkg_resources.get_distribution("stor").version
+except Exception:  # pragma: no cover
     # we are not pip installed in environment
     __version__ = None
 

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -22,6 +22,7 @@ See `stor.swift` for more information on Swift-specific functionality.
 """
 try:
     from importlib import metadata
+# TODO: remove fallback once support for Python < 3.8 is dropped
 except ImportError:  # Python < 3.8
     try:
         import importlib_metadata as metadata

--- a/stor/__init__.py
+++ b/stor/__init__.py
@@ -20,7 +20,7 @@ functions.
 
 See `stor.swift` for more information on Swift-specific functionality.
 """
-import pkg_resources
+from importlib import metadata
 
 from stor.utils import copy
 from stor.utils import copytree
@@ -34,8 +34,8 @@ from stor import settings
 
 # TODO: Compile this - costs ~700us to do this on import
 try:
-    __version__ = pkg_resources.get_distribution('stor').version
-except pkg_resources.DistributionNotFound:  # pragma: no cover
+    __version__ = metadata.version("stor")
+except metadata.PackageNotFoundError:  # pragma: no cover
     # we are not pip installed in environment
     __version__ = None
 


### PR DESCRIPTION
## Description
`pkg_resources` is being deprecated and all applications that install stor are unable to upgrade the setuptools version due to its use of `pkg_resources`.  Instead of `pkg_resources`, we should use `importlib`'s `metadata`.

### Changes
- Updated use of `pkg_resources` to `importlib`'s `metadata` in `__init__.py`. Fall back import and use for older version of python.
- Updated CI/CD to run on `ubuntu-22.04` runners with updated action version tags.

### Testing
- CI/CD successful for python 3.7 and 3.8.

